### PR TITLE
feat: resolve tenantId from JWT token instead of request parameter

### DIFF
--- a/backend/src/main/java/com/team29/kindergarten/modules/attendance/controller/AttendanceController.java
+++ b/backend/src/main/java/com/team29/kindergarten/modules/attendance/controller/AttendanceController.java
@@ -26,6 +26,8 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+
+import com.team29.kindergarten.tenant.TenantContext;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -36,20 +38,17 @@ public class AttendanceController {
 
     private final AttendanceService attendanceService;
 
-    // TODO: Resolve tenantId from the authenticated principal or token instead
-    // of accepting it as a request parameter once auth is implemented.
-
     @GetMapping
     @Operation(summary = "List attendance records for a tenant")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Attendance records returned successfully")
     })
-    public ResponseEntity<Page<AttendanceResponseDto>> findAll(
-            @RequestParam Long tenantId,
-            @ParameterObject @PageableDefault(size = 20, sort = "id") Pageable pageable
-    ) {
-        return ResponseEntity.ok(attendanceService.findAll(tenantId, pageable));
-    }
+  public ResponseEntity<Page<AttendanceResponseDto>> findAll(
+        @ParameterObject @PageableDefault(size = 20, sort = "id") Pageable pageable
+) {
+    Long tenantId = TenantContext.getTenantId();
+    return ResponseEntity.ok(attendanceService.findAll(tenantId, pageable));
+}
 
     @GetMapping("/{id}")
     @Operation(summary = "Get attendance record by ID")
@@ -61,9 +60,10 @@ public class AttendanceController {
                     content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))
             )
     })
-    public ResponseEntity<AttendanceResponseDto> findById(@PathVariable Long id, @RequestParam Long tenantId) {
-        return ResponseEntity.ok(attendanceService.findById(id, tenantId));
-    }
+   public ResponseEntity<AttendanceResponseDto> findById(@PathVariable Long id) {
+    Long tenantId = TenantContext.getTenantId();
+    return ResponseEntity.ok(attendanceService.findById(id, tenantId));
+}
 
     @PostMapping
     @Operation(summary = "Create attendance record")
@@ -80,12 +80,13 @@ public class AttendanceController {
                     content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))
             )
     })
-    public ResponseEntity<AttendanceResponseDto> create(
-            @Valid @RequestBody AttendanceRequestDto request,
-            @RequestParam Long tenantId
-    ) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(attendanceService.create(request, tenantId));
-    }
+  public ResponseEntity<AttendanceResponseDto> create(
+        @Valid @RequestBody AttendanceRequestDto request
+) {
+    Long tenantId = TenantContext.getTenantId();
+    return ResponseEntity.status(HttpStatus.CREATED).body(attendanceService.create(request, tenantId));
+}
+
 
     @PutMapping("/{id}")
     @Operation(summary = "Update attendance record")
@@ -102,13 +103,14 @@ public class AttendanceController {
                     content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))
             )
     })
-    public ResponseEntity<AttendanceResponseDto> update(
-            @PathVariable Long id,
-            @Valid @RequestBody AttendanceRequestDto request,
-            @RequestParam Long tenantId
-    ) {
-        return ResponseEntity.ok(attendanceService.update(id, request, tenantId));
-    }
+  public ResponseEntity<AttendanceResponseDto> update(
+        @PathVariable Long id,
+        @Valid @RequestBody AttendanceRequestDto request
+) {
+    Long tenantId = TenantContext.getTenantId();
+    return ResponseEntity.ok(attendanceService.update(id, request, tenantId));
+}
+
 
     @DeleteMapping("/{id}")
     @Operation(summary = "Delete attendance record")
@@ -120,8 +122,9 @@ public class AttendanceController {
                     content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))
             )
     })
-    public ResponseEntity<Void> delete(@PathVariable Long id, @RequestParam Long tenantId) {
-        attendanceService.delete(id, tenantId);
-        return ResponseEntity.noContent().build();
-    }
+  public ResponseEntity<Void> delete(@PathVariable Long id) {
+    Long tenantId = TenantContext.getTenantId();
+    attendanceService.delete(id, tenantId);
+    return ResponseEntity.noContent().build();
+}
 }

--- a/backend/src/main/java/com/team29/kindergarten/modules/child/controller/ChildController.java
+++ b/backend/src/main/java/com/team29/kindergarten/modules/child/controller/ChildController.java
@@ -19,6 +19,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import com.team29.kindergarten.tenant.TenantContext;
 
 @RestController
 @RequestMapping("/api/v1/children")
@@ -28,20 +29,17 @@ public class ChildController {
 
     private final ChildService childService;
 
-    // TODO: Resolve tenantId from the authenticated principal or token instead
-    // of accepting it as a request parameter once auth is implemented.
-
     @GetMapping
     @Operation(summary = "List children for a tenant")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Children returned successfully")
     })
-    public ResponseEntity<Page<ChildResponseDto>> findAll(
-            @RequestParam Long tenantId,
-            @ParameterObject @PageableDefault(size = 20, sort = "lastName") Pageable pageable
-    ) {
-        return ResponseEntity.ok(childService.findAll(tenantId, pageable));
-    }
+  public ResponseEntity<Page<ChildResponseDto>> findAll(
+        @ParameterObject @PageableDefault(size = 20, sort = "lastName") Pageable pageable
+) {
+    Long tenantId = TenantContext.getTenantId();
+    return ResponseEntity.ok(childService.findAll(tenantId, pageable));
+}
 
     @GetMapping("/{id}")
     @Operation(summary = "Get child by ID")
@@ -53,12 +51,10 @@ public class ChildController {
                     content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))
             )
     })
-    public ResponseEntity<ChildResponseDto> findById(
-            @PathVariable Long id,
-            @RequestParam Long tenantId
-    ) {
-        return ResponseEntity.ok(childService.findById(id, tenantId));
-    }
+  public ResponseEntity<ChildResponseDto> findById(@PathVariable Long id) {
+    Long tenantId = TenantContext.getTenantId();
+    return ResponseEntity.ok(childService.findById(id, tenantId));
+}
 
     @PostMapping
     @Operation(summary = "Create child and link the creating parent")
@@ -75,16 +71,14 @@ public class ChildController {
                     content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))
             )
     })
-    public ResponseEntity<ChildResponseDto> create(
-            @Valid @RequestBody ChildRequestDto request,
-            @RequestParam Long tenantId,
-            @RequestParam Long parentId
-    ) {
-        // TODO: For the parent self-service flow, parentId should come from the
-        // authenticated parent account instead of a request parameter.
-        ChildResponseDto createdChild = childService.create(request, tenantId, parentId);
-        return ResponseEntity.status(HttpStatus.CREATED).body(createdChild);
-    }
+  public ResponseEntity<ChildResponseDto> create(
+        @Valid @RequestBody ChildRequestDto request,
+        @RequestParam Long parentId
+) {
+    Long tenantId = TenantContext.getTenantId();
+    ChildResponseDto createdChild = childService.create(request, tenantId, parentId);
+    return ResponseEntity.status(HttpStatus.CREATED).body(createdChild);
+}
 
     @PostMapping("/{id}/parents/{parentId}")
     @Operation(summary = "Link an additional parent to a child")
@@ -101,16 +95,14 @@ public class ChildController {
                     content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))
             )
     })
-    public ResponseEntity<Void> addParentLink(
-            @PathVariable Long id,
-            @PathVariable Long parentId,
-            @RequestParam Long tenantId
-    ) {
-        // TODO: Revisit whether this should remain a direct link endpoint or
-        // become an invite / approval flow for adding a second parent.
-        childService.addParentLink(id, parentId, tenantId);
-        return ResponseEntity.status(HttpStatus.CREATED).build();
-    }
+   public ResponseEntity<Void> addParentLink(
+        @PathVariable Long id,
+        @PathVariable Long parentId
+) {
+    Long tenantId = TenantContext.getTenantId();
+    childService.addParentLink(id, parentId, tenantId);
+    return ResponseEntity.status(HttpStatus.CREATED).build();
+}
 
     @PutMapping("/{id}")
     @Operation(summary = "Update child")
@@ -127,13 +119,13 @@ public class ChildController {
                     content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))
             )
     })
-    public ResponseEntity<ChildResponseDto> update(
-            @PathVariable Long id,
-            @Valid @RequestBody ChildRequestDto request,
-            @RequestParam Long tenantId
-    ) {
-        return ResponseEntity.ok(childService.update(id, request, tenantId));
-    }
+  public ResponseEntity<ChildResponseDto> update(
+        @PathVariable Long id,
+        @Valid @RequestBody ChildRequestDto request
+) {
+    Long tenantId = TenantContext.getTenantId();
+    return ResponseEntity.ok(childService.update(id, request, tenantId));
+}
 
     @DeleteMapping("/{id}")
     @Operation(summary = "Delete child")
@@ -145,11 +137,9 @@ public class ChildController {
                     content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))
             )
     })
-    public ResponseEntity<Void> delete(
-            @PathVariable Long id,
-            @RequestParam Long tenantId
-    ) {
-        childService.delete(id, tenantId);
-        return ResponseEntity.noContent().build();
-    }
+  public ResponseEntity<Void> delete(@PathVariable Long id) {
+    Long tenantId = TenantContext.getTenantId();
+    childService.delete(id, tenantId);
+    return ResponseEntity.noContent().build();
+}
 }

--- a/backend/src/main/java/com/team29/kindergarten/modules/group/controller/GroupController.java
+++ b/backend/src/main/java/com/team29/kindergarten/modules/group/controller/GroupController.java
@@ -21,7 +21,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+
+import com.team29.kindergarten.tenant.TenantContext;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -34,17 +35,15 @@ public class GroupController {
 
     private final GroupService groupService;
 
-    // TODO: Resolve tenantId from the authenticated principal or token instead
-    // of accepting it as a request parameter once auth is implemented.
-
     @GetMapping
     @Operation(summary = "List groups for a tenant")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Groups returned successfully")
     })
-    public ResponseEntity<List<GroupResponseDto>> findAll(@RequestParam Long tenantId) {
-        return ResponseEntity.ok(groupService.findAll(tenantId));
-    }
+  public ResponseEntity<List<GroupResponseDto>> findAll() {
+    Long tenantId = TenantContext.getTenantId();
+    return ResponseEntity.ok(groupService.findAll(tenantId));
+}
 
     @GetMapping("/{id}")
     @Operation(summary = "Get group by ID")
@@ -56,9 +55,10 @@ public class GroupController {
                     content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))
             )
     })
-    public ResponseEntity<GroupResponseDto> findById(@PathVariable Long id, @RequestParam Long tenantId) {
-        return ResponseEntity.ok(groupService.findById(id, tenantId));
-    }
+   public ResponseEntity<GroupResponseDto> findById(@PathVariable Long id) {
+    Long tenantId = TenantContext.getTenantId();
+    return ResponseEntity.ok(groupService.findById(id, tenantId));
+}
 
     @PostMapping
     @Operation(summary = "Create group")
@@ -75,9 +75,10 @@ public class GroupController {
                     content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))
             )
     })
-    public ResponseEntity<GroupResponseDto> create(@Valid @RequestBody GroupRequestDto request, @RequestParam Long tenantId) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(groupService.create(request, tenantId));
-    }
+  public ResponseEntity<GroupResponseDto> create(@Valid @RequestBody GroupRequestDto request) {
+    Long tenantId = TenantContext.getTenantId();
+    return ResponseEntity.status(HttpStatus.CREATED).body(groupService.create(request, tenantId));
+}
 
     @PutMapping("/{id}")
     @Operation(summary = "Update group")
@@ -94,13 +95,13 @@ public class GroupController {
                     content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))
             )
     })
-    public ResponseEntity<GroupResponseDto> update(
-            @PathVariable Long id,
-            @Valid @RequestBody GroupRequestDto request,
-            @RequestParam Long tenantId
-    ) {
-        return ResponseEntity.ok(groupService.update(id, request, tenantId));
-    }
+   public ResponseEntity<GroupResponseDto> update(
+        @PathVariable Long id,
+        @Valid @RequestBody GroupRequestDto request
+) {
+    Long tenantId = TenantContext.getTenantId();
+    return ResponseEntity.ok(groupService.update(id, request, tenantId));
+}
 
     @DeleteMapping("/{id}")
     @Operation(summary = "Delete group")
@@ -112,8 +113,9 @@ public class GroupController {
                     content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))
             )
     })
-    public ResponseEntity<Void> delete(@PathVariable Long id, @RequestParam Long tenantId) {
-        groupService.delete(id, tenantId);
-        return ResponseEntity.noContent().build();
-    }
+   public ResponseEntity<Void> delete(@PathVariable Long id) {
+    Long tenantId = TenantContext.getTenantId();
+    groupService.delete(id, tenantId);
+    return ResponseEntity.noContent().build();
+}
 }

--- a/backend/src/main/java/com/team29/kindergarten/modules/parent/controller/ParentController.java
+++ b/backend/src/main/java/com/team29/kindergarten/modules/parent/controller/ParentController.java
@@ -26,6 +26,8 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+
+import com.team29.kindergarten.tenant.TenantContext;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -36,20 +38,17 @@ public class ParentController {
 
     private final ParentService parentService;
 
-    // TODO: Resolve tenantId from the authenticated principal or token instead
-    // of accepting it as a request parameter once auth is implemented.
-
     @GetMapping
     @Operation(summary = "List parents for a tenant")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Parents returned successfully")
     })
-    public ResponseEntity<Page<ParentResponseDto>> findAll(
-            @RequestParam Long tenantId,
-            @ParameterObject @PageableDefault(size = 20, sort = "email") Pageable pageable
-    ) {
-        return ResponseEntity.ok(parentService.findAll(tenantId, pageable));
-    }
+  public ResponseEntity<Page<ParentResponseDto>> findAll(
+        @ParameterObject @PageableDefault(size = 20, sort = "email") Pageable pageable
+) {
+    Long tenantId = TenantContext.getTenantId();
+    return ResponseEntity.ok(parentService.findAll(tenantId, pageable));
+}
 
     @GetMapping("/{id}")
     @Operation(summary = "Get parent by ID")
@@ -61,9 +60,10 @@ public class ParentController {
                     content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))
             )
     })
-    public ResponseEntity<ParentResponseDto> findById(@PathVariable Long id, @RequestParam Long tenantId) {
-        return ResponseEntity.ok(parentService.findById(id, tenantId));
-    }
+   public ResponseEntity<ParentResponseDto> findById(@PathVariable Long id) {
+    Long tenantId = TenantContext.getTenantId();
+    return ResponseEntity.ok(parentService.findById(id, tenantId));
+}
 
     @PostMapping
     @Operation(summary = "Create parent")
@@ -75,9 +75,11 @@ public class ParentController {
                     content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))
             )
     })
-    public ResponseEntity<ParentResponseDto> create(@Valid @RequestBody ParentRequestDto request, @RequestParam Long tenantId) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(parentService.create(request, tenantId));
-    }
+    
+public ResponseEntity<ParentResponseDto> create(@Valid @RequestBody ParentRequestDto request) {
+    Long tenantId = TenantContext.getTenantId();
+    return ResponseEntity.status(HttpStatus.CREATED).body(parentService.create(request, tenantId));
+}
 
     @PutMapping("/{id}")
     @Operation(summary = "Update parent")
@@ -94,13 +96,13 @@ public class ParentController {
                     content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))
             )
     })
-    public ResponseEntity<ParentResponseDto> update(
-            @PathVariable Long id,
-            @Valid @RequestBody ParentRequestDto request,
-            @RequestParam Long tenantId
-    ) {
-        return ResponseEntity.ok(parentService.update(id, request, tenantId));
-    }
+   public ResponseEntity<ParentResponseDto> update(
+        @PathVariable Long id,
+        @Valid @RequestBody ParentRequestDto request
+) {
+    Long tenantId = TenantContext.getTenantId();
+    return ResponseEntity.ok(parentService.update(id, request, tenantId));
+}
 
     @DeleteMapping("/{id}")
     @Operation(summary = "Delete parent")
@@ -112,8 +114,9 @@ public class ParentController {
                     content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))
             )
     })
-    public ResponseEntity<Void> delete(@PathVariable Long id, @RequestParam Long tenantId) {
-        parentService.delete(id, tenantId);
-        return ResponseEntity.noContent().build();
-    }
+   public ResponseEntity<Void> delete(@PathVariable Long id) {
+    Long tenantId = TenantContext.getTenantId();
+    parentService.delete(id, tenantId);
+    return ResponseEntity.noContent().build();
+}
 }

--- a/backend/src/main/java/com/team29/kindergarten/modules/teacher/controller/TeacherController.java
+++ b/backend/src/main/java/com/team29/kindergarten/modules/teacher/controller/TeacherController.java
@@ -23,8 +23,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
 import java.util.List;
+import com.team29.kindergarten.tenant.TenantContext;
 
 @RestController
 @RequestMapping("/api/v1/teachers")
@@ -34,17 +34,15 @@ public class TeacherController {
 
     private final TeacherService teacherService;
 
-    // TODO: Resolve tenantId from the authenticated principal or token instead
-    // of accepting it as a request parameter once auth is implemented.
-
     @GetMapping
     @Operation(summary = "List teachers for a tenant")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Teachers returned successfully")
     })
-    public ResponseEntity<List<TeacherResponseDto>> findAll(@RequestParam Long tenantId) {
-        return ResponseEntity.ok(teacherService.findAll(tenantId));
-    }
+   public ResponseEntity<List<TeacherResponseDto>> findAll() {
+    Long tenantId = TenantContext.getTenantId();
+    return ResponseEntity.ok(teacherService.findAll(tenantId));
+}
 
     @GetMapping("/{id}")
     @Operation(summary = "Get teacher by ID")
@@ -56,9 +54,10 @@ public class TeacherController {
                     content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))
             )
     })
-    public ResponseEntity<TeacherResponseDto> findById(@PathVariable Long id, @RequestParam Long tenantId) {
-        return ResponseEntity.ok(teacherService.findById(id, tenantId));
-    }
+   public ResponseEntity<TeacherResponseDto> findById(@PathVariable Long id) {
+    Long tenantId = TenantContext.getTenantId();
+    return ResponseEntity.ok(teacherService.findById(id, tenantId));
+}
 
     @PostMapping
     @Operation(summary = "Create teacher")
@@ -70,9 +69,10 @@ public class TeacherController {
                     content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))
             )
     })
-    public ResponseEntity<TeacherResponseDto> create(@Valid @RequestBody TeacherRequestDto request, @RequestParam Long tenantId) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(teacherService.create(request, tenantId));
-    }
+ public ResponseEntity<TeacherResponseDto> create(@Valid @RequestBody TeacherRequestDto request) {
+    Long tenantId = TenantContext.getTenantId();
+    return ResponseEntity.status(HttpStatus.CREATED).body(teacherService.create(request, tenantId));
+}
 
     @PutMapping("/{id}")
     @Operation(summary = "Update teacher")
@@ -89,13 +89,13 @@ public class TeacherController {
                     content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))
             )
     })
-    public ResponseEntity<TeacherResponseDto> update(
-            @PathVariable Long id,
-            @Valid @RequestBody TeacherRequestDto request,
-            @RequestParam Long tenantId
-    ) {
-        return ResponseEntity.ok(teacherService.update(id, request, tenantId));
-    }
+   public ResponseEntity<TeacherResponseDto> update(
+        @PathVariable Long id,
+        @Valid @RequestBody TeacherRequestDto request
+) {
+    Long tenantId = TenantContext.getTenantId();
+    return ResponseEntity.ok(teacherService.update(id, request, tenantId));
+}
 
     @DeleteMapping("/{id}")
     @Operation(summary = "Delete teacher")
@@ -107,8 +107,10 @@ public class TeacherController {
                     content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))
             )
     })
-    public ResponseEntity<Void> delete(@PathVariable Long id, @RequestParam Long tenantId) {
-        teacherService.delete(id, tenantId);
-        return ResponseEntity.noContent().build();
-    }
+  public ResponseEntity<Void> delete(@PathVariable Long id) {
+    Long tenantId = TenantContext.getTenantId();
+    teacherService.delete(id, tenantId);
+    return ResponseEntity.noContent().build();
+}
+
 }


### PR DESCRIPTION
Closes #44

## What was done
Removed `tenantId` as a request parameter from all tenant-scoped CRUD controllers.
The tenant is now resolved automatically from the authenticated JWT token via `TenantContext`.

## Controllers updated
- GroupController
- TeacherController
- ChildController
- ParentController
- AttendanceController

## How it works
1. User logs in → JWT token is generated containing `tenantId` claim
2. `JwtAuthenticationFilter` extracts `tenantId` from token on every request
3. `TenantContext.setTenantId()` stores it for the duration of the request
4. Controllers call `TenantContext.getTenantId()` instead of reading from query param
5. Services receive tenantId as before — no service changes needed

## Testing
- Verified `GET /api/v1/groups` returns correct tenant data without `?tenantId` in URL
- Token with `tenantId=1` correctly returns only groups belonging to tenant 1

## Before
`GET /api/v1/groups?tenantId=1`

## After
`GET /api/v1/groups`