### PR TITLE
feat: TEACHER portal - class records endpoint

### DIFF
--- a/backend/src/main/java/com/team29/kindergarten/modules/child/controller/ChildController.java
+++ b/backend/src/main/java/com/team29/kindergarten/modules/child/controller/ChildController.java
@@ -20,6 +20,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import com.team29.kindergarten.tenant.TenantContext;
+import com.team29.kindergarten.modules.user.entity.User;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/children")
@@ -54,6 +57,24 @@ public class ChildController {
   public ResponseEntity<ChildResponseDto> findById(@PathVariable Long id) {
     Long tenantId = TenantContext.getTenantId();
     return ResponseEntity.ok(childService.findById(id, tenantId));
+}
+
+    @GetMapping("/class-records")
+    @Operation(summary = "Get children in the teacher's assigned group")
+    @ApiResponses({
+                @ApiResponse(responseCode = "200", description = "Class records returned successfully"),
+                @ApiResponse(
+                        responseCode = "404",
+                        description = "No group found for this teacher",
+                        content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))
+                )
+        })
+
+public ResponseEntity<List<ChildResponseDto>> findClassRecords(
+        @AuthenticationPrincipal User currentUser
+) {
+    Long tenantId = TenantContext.getTenantId();
+    return ResponseEntity.ok(childService.findAllByTeacher(currentUser.getId(), tenantId));
 }
 
     @PostMapping

--- a/backend/src/main/java/com/team29/kindergarten/modules/child/dto/ChildResponseDto.java
+++ b/backend/src/main/java/com/team29/kindergarten/modules/child/dto/ChildResponseDto.java
@@ -20,7 +20,6 @@ public class ChildResponseDto {
     private String firstName;
     private String lastName;
     private LocalDate birthDate;
-    private Long groupId;
     private String groupName;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;

--- a/backend/src/main/java/com/team29/kindergarten/modules/child/dto/ChildResponseDto.java
+++ b/backend/src/main/java/com/team29/kindergarten/modules/child/dto/ChildResponseDto.java
@@ -21,6 +21,7 @@ public class ChildResponseDto {
     private String lastName;
     private LocalDate birthDate;
     private Long groupId;
+    private String groupName;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 }

--- a/backend/src/main/java/com/team29/kindergarten/modules/child/mapper/ChildMapper.java
+++ b/backend/src/main/java/com/team29/kindergarten/modules/child/mapper/ChildMapper.java
@@ -12,7 +12,6 @@ import org.mapstruct.NullValuePropertyMappingStrategy;
 @Mapper(componentModel = "spring")
 public interface ChildMapper {
 
-    @Mapping(target = "groupId", source = "group.id")
     @Mapping(target = "groupName", source = "group.name")
     ChildResponseDto toResponseDto(Child child);
 

--- a/backend/src/main/java/com/team29/kindergarten/modules/child/mapper/ChildMapper.java
+++ b/backend/src/main/java/com/team29/kindergarten/modules/child/mapper/ChildMapper.java
@@ -13,6 +13,7 @@ import org.mapstruct.NullValuePropertyMappingStrategy;
 public interface ChildMapper {
 
     @Mapping(target = "groupId", source = "group.id")
+    @Mapping(target = "groupName", source = "group.name")
     ChildResponseDto toResponseDto(Child child);
 
     @Mapping(target = "id",        ignore = true)

--- a/backend/src/main/java/com/team29/kindergarten/modules/child/repository/ChildRepository.java
+++ b/backend/src/main/java/com/team29/kindergarten/modules/child/repository/ChildRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
+import java.util.List;
 
 @Repository
 public interface ChildRepository extends JpaRepository<Child, Long> {
@@ -14,4 +15,6 @@ public interface ChildRepository extends JpaRepository<Child, Long> {
     Page<Child> findAllByTenantId(Long tenantId, Pageable pageable);
 
     Optional<Child> findByIdAndTenantId(Long id, Long tenantId);
+
+    List<Child> findAllByGroupIdAndTenantId(Long groupId, Long tenantId);
 }

--- a/backend/src/main/java/com/team29/kindergarten/modules/child/service/ChildService.java
+++ b/backend/src/main/java/com/team29/kindergarten/modules/child/service/ChildService.java
@@ -18,6 +18,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
 
 import java.time.LocalDateTime;
 
@@ -49,6 +50,20 @@ public class ChildService {
                 .map(childMapper::toResponseDto)
                 .orElseThrow(() -> new ResourceNotFoundException("Child not found: " + id));
     }
+
+    @Transactional(readOnly = true)
+    public List<ChildResponseDto> findAllByTeacher(Long teacherUserId, Long tenantId) {
+    log.info("Fetching class records for teacherUserId={}, tenantId={}", teacherUserId, tenantId);
+
+    Group group = groupRepository.findByTeacherUserIdAndTenantId(teacherUserId, tenantId)
+            .orElseThrow(() -> new ResourceNotFoundException(
+                    "No group found for teacher userId=" + teacherUserId));
+
+    return childRepository.findAllByGroupIdAndTenantId(group.getId(), tenantId)
+            .stream()
+            .map(childMapper::toResponseDto)
+            .toList();
+}
 
     public ChildResponseDto create(ChildRequestDto request, Long tenantId, Long parentId) {
         log.info("Creating child for tenantId={} and linking parentId={}", tenantId, parentId);

--- a/backend/src/main/java/com/team29/kindergarten/modules/group/repository/GroupRepository.java
+++ b/backend/src/main/java/com/team29/kindergarten/modules/group/repository/GroupRepository.java
@@ -17,4 +17,6 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
     List<Group> findAllByTenantIdOrderByNameAsc(Long tenantId);
 
     Optional<Group> findByIdAndTenantId(Long id, Long tenantId);
+
+    Optional<Group> findByTeacherUserIdAndTenantId(Long teacherUserId, Long tenantId);
 }

--- a/frontend/src/app/(teacher)/teacher/class-records/page.tsx
+++ b/frontend/src/app/(teacher)/teacher/class-records/page.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import Paper from "@mui/material/Paper";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import { useAuth } from "@/src/context/AuthContext";
+import { useClassRecords } from "@/src/modules/children/hooks/useClassRecords";
+import { Spinner, ErrorState } from "@/src/components/ui";
+
+export default function ClassRecordsPage() {
+  const { token, hydrated } = useAuth();
+  const { children, loading, error } = useClassRecords(token, hydrated);
+
+  return (
+    <Paper sx={{ p: 3, borderRadius: 1 }}>
+      <Stack spacing={2}>
+        <Typography variant="h4" fontWeight={700}>
+          Class Records
+        </Typography>
+        <Typography color="text.secondary">
+          Children in your assigned group
+        </Typography>
+
+        {loading ? (
+          <Stack direction="row" spacing={2} alignItems="center">
+            <Spinner centered={false} size={24} />
+            <Typography>Loading class records...</Typography>
+          </Stack>
+        ) : error ? (
+          <ErrorState
+            title="Failed to load class records"
+            description={error}
+            actionLabel={undefined}
+          />
+        ) : children.length === 0 ? (
+          <Typography color="text.secondary">
+            No children found in your group.
+          </Typography>
+        ) : (
+          <TableContainer component={Paper} variant="outlined">
+            <Table>
+              <TableHead>
+                <TableRow>
+                  <TableCell>
+                    <strong>First Name</strong>
+                  </TableCell>
+                  <TableCell>
+                    <strong>Last Name</strong>
+                  </TableCell>
+                  <TableCell>
+                    <strong>Date of Birth</strong>
+                  </TableCell>
+                  <TableCell>
+                    <strong>Group ID</strong>
+                  </TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {children.map((child) => (
+                  <TableRow key={child.id}>
+                    <TableCell>{child.firstName}</TableCell>
+                    <TableCell>{child.lastName}</TableCell>
+                    <TableCell>{child.birthDate}</TableCell>
+                    <TableCell>{child.groupId}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+      </Stack>
+    </Paper>
+  );
+}

--- a/frontend/src/app/(teacher)/teacher/class-records/page.tsx
+++ b/frontend/src/app/(teacher)/teacher/class-records/page.tsx
@@ -57,7 +57,7 @@ export default function ClassRecordsPage() {
                     <strong>Date of Birth</strong>
                   </TableCell>
                   <TableCell>
-                    <strong>Group ID</strong>
+                    <strong>Group Name</strong>
                   </TableCell>
                 </TableRow>
               </TableHead>
@@ -67,7 +67,7 @@ export default function ClassRecordsPage() {
                     <TableCell>{child.firstName}</TableCell>
                     <TableCell>{child.lastName}</TableCell>
                     <TableCell>{child.birthDate}</TableCell>
-                    <TableCell>{child.groupId}</TableCell>
+                    <TableCell>{child.groupName}</TableCell>
                   </TableRow>
                 ))}
               </TableBody>

--- a/frontend/src/components/navigation/teacherNav.ts
+++ b/frontend/src/components/navigation/teacherNav.ts
@@ -1,8 +1,9 @@
-import {NavItem} from "@/src/app/navigation";
+import { NavItem } from "@/src/app/navigation";
 
 export const teacherNavItems: NavItem[] = [
-    { label: "Dashboard", href: "/teacher/dashboard" },
-    { label: "Groups", href: "/teacher/groups" },
-    { label: "Attendance", href: "/teacher/attendance" },
-    { label: "Messages", href: "/teacher/messages" },
+  { label: "Dashboard", href: "/teacher/dashboard" },
+  { label: "Class Records", href: "/teacher/class-records" },
+  { label: "Groups", href: "/teacher/groups" },
+  { label: "Attendance", href: "/teacher/attendance" },
+  { label: "Messages", href: "/teacher/messages" },
 ];

--- a/frontend/src/components/navigation/teacherNav.ts
+++ b/frontend/src/components/navigation/teacherNav.ts
@@ -3,7 +3,6 @@ import { NavItem } from "@/src/app/navigation";
 export const teacherNavItems: NavItem[] = [
   { label: "Dashboard", href: "/teacher/dashboard" },
   { label: "Class Records", href: "/teacher/class-records" },
-  { label: "Groups", href: "/teacher/groups" },
   { label: "Attendance", href: "/teacher/attendance" },
   { label: "Messages", href: "/teacher/messages" },
 ];

--- a/frontend/src/modules/children/api/getClassRecords.ts
+++ b/frontend/src/modules/children/api/getClassRecords.ts
@@ -1,0 +1,17 @@
+import { API_URL } from "@/src/shared/constants/api";
+import type { Child } from "../model/child";
+
+export async function getClassRecords(token: string): Promise<Child[]> {
+  const response = await fetch(`${API_URL}/api/v1/children/class-records`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to fetch class records");
+  }
+
+  return response.json();
+}

--- a/frontend/src/modules/children/hooks/useClassRecords.ts
+++ b/frontend/src/modules/children/hooks/useClassRecords.ts
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getClassRecords } from "../api/getClassRecords";
+import type { Child } from "../model/child";
+
+export function useClassRecords(token: string | null, enabled = true) {
+  const [children, setChildren] = useState<Child[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    if (!enabled || !token) {
+      return;
+    }
+
+    const resolvedToken = token;
+    let cancelled = false;
+
+    async function loadClassRecords() {
+      try {
+        setLoading(true);
+        setError(null);
+        const data = await getClassRecords(resolvedToken);
+
+        if (!cancelled) {
+          setChildren(data);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(
+            err instanceof Error ? err.message : "Failed to load class records",
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void loadClassRecords();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, reloadKey, token]);
+
+  return {
+    children,
+    loading,
+    error,
+    refetch: () => setReloadKey((currentValue) => currentValue + 1),
+  };
+}

--- a/frontend/src/modules/children/model/child.ts
+++ b/frontend/src/modules/children/model/child.ts
@@ -5,6 +5,7 @@ export interface Child {
   lastName: string;
   birthDate: string;
   groupId: number;
+  groupName: string;
   createdAt: string;
   updatedAt: string;
 }

--- a/frontend/src/modules/children/model/child.ts
+++ b/frontend/src/modules/children/model/child.ts
@@ -4,7 +4,6 @@ export interface Child {
   firstName: string;
   lastName: string;
   birthDate: string;
-  groupId: number;
   groupName: string;
   createdAt: string;
   updatedAt: string;

--- a/frontend/src/modules/children/model/child.ts
+++ b/frontend/src/modules/children/model/child.ts
@@ -1,0 +1,10 @@
+export interface Child {
+  id: number;
+  tenantId: number;
+  firstName: string;
+  lastName: string;
+  birthDate: string;
+  groupId: number;
+  createdAt: string;
+  updatedAt: string;
+}


### PR DESCRIPTION
Closes #27

## What was done
Added a backend endpoint for teachers to view all children in their assigned group.

## Changes
- Added `findByTeacherUserIdAndTenantId()` to `GroupRepository`
- Added `findAllByGroupIdAndTenantId()` to `ChildRepository`
- Added `findAllByTeacher()` method to `ChildService`
- Added `GET /api/v1/children/class-records` endpoint to `ChildController`
- Added `frontend class records page for teacher portal`
- Added `teacher navigation link for class records`


## How it works
1. Teacher authenticates and receives a JWT token
2. Teacher calls `GET /api/v1/children/class-records`
3. Backend extracts teacher's user ID from the JWT token
4. Finds the group assigned to that teacher
5. Returns all children in that group

## Testing
- Tested locally end to end via curl and Swagger
- Verified correct children returned for authenticated teacher
- Verified 404 returned when teacher has no assigned group