### PR TITLE
feat: add search functionality to groups and teachers tables (#59)

### DIFF
--- a/backend/src/main/java/com/team29/kindergarten/modules/group/controller/GroupController.java
+++ b/backend/src/main/java/com/team29/kindergarten/modules/group/controller/GroupController.java
@@ -25,6 +25,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import com.team29.kindergarten.tenant.TenantContext;
 import org.springframework.web.bind.annotation.RestController;
@@ -39,16 +40,17 @@ public class GroupController {
 
     private final GroupService groupService;
 
-    @GetMapping
-    @Operation(summary = "List groups for a tenant")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Groups returned successfully")
-    })
-  public ResponseEntity<PageResponseDto<GroupResponseDto>> findAll(
+@GetMapping
+@Operation(summary = "List groups for a tenant")
+@ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Groups returned successfully")
+})
+public ResponseEntity<PageResponseDto<GroupResponseDto>> findAll(
+        @RequestParam(required = false) String search,
         @ParameterObject @PageableDefault(size = 20, sort = "name") Pageable pageable
 ) {
     Long tenantId = TenantContext.getTenantId();
-    return ResponseEntity.ok(PageResponseDto.from(groupService.findAll(tenantId, pageable)));
+    return ResponseEntity.ok(PageResponseDto.from(groupService.findAll(tenantId, search, pageable)));
 }
 
     @GetMapping("/options")

--- a/backend/src/main/java/com/team29/kindergarten/modules/group/repository/GroupRepository.java
+++ b/backend/src/main/java/com/team29/kindergarten/modules/group/repository/GroupRepository.java
@@ -14,6 +14,8 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
 
     Page<Group> findAllByTenantId(Long tenantId, Pageable pageable);
 
+    Page<Group> findAllByTenantIdAndNameContainingIgnoreCase(Long tenantId, String name, Pageable pageable);
+
     List<Group> findAllByTenantIdOrderByNameAsc(Long tenantId);
 
     List<Group> findAllByTeacherUserIdInAndTenantId(List<Long> teacherUserIds, Long tenantId);

--- a/backend/src/main/java/com/team29/kindergarten/modules/group/service/GroupService.java
+++ b/backend/src/main/java/com/team29/kindergarten/modules/group/service/GroupService.java
@@ -32,11 +32,15 @@ public class GroupService {
     private final UserRepository userRepository;
     private final ChildRepository childRepository;
 
-    @Transactional(readOnly = true)
-    public Page<GroupResponseDto> findAll(Long tenantId, Pageable pageable) {
-        return groupRepository.findAllByTenantId(tenantId, pageable)
+   @Transactional(readOnly = true)
+public Page<GroupResponseDto> findAll(Long tenantId, String search, Pageable pageable) {
+    if (search != null && !search.isBlank()) {
+        return groupRepository.findAllByTenantIdAndNameContainingIgnoreCase(tenantId, search, pageable)
                 .map(groupMapper::toResponseDto);
     }
+    return groupRepository.findAllByTenantId(tenantId, pageable)
+            .map(groupMapper::toResponseDto);
+}
 
     @Transactional(readOnly = true)
     public List<GroupResponseDto> findAllOptions(Long tenantId) {

--- a/backend/src/main/java/com/team29/kindergarten/modules/user/controller/UserController.java
+++ b/backend/src/main/java/com/team29/kindergarten/modules/user/controller/UserController.java
@@ -47,12 +47,13 @@ public class UserController {
             @ApiResponse(responseCode = "200", description = "Users returned successfully")
     })
     public ResponseEntity<PageResponseDto<UserResponseDto>> findUsersByRole(
-            @RequestParam RoleName role,
-            @ParameterObject @PageableDefault(size = 20, sort = "fullName") Pageable pageable
-    ) {
-        Long tenantId = TenantContext.getTenantId();
-        return ResponseEntity.ok(PageResponseDto.from(userService.findUsersByRole(tenantId, role, pageable)));
-    }
+        @RequestParam RoleName role,
+        @RequestParam(required = false) String search,
+        @ParameterObject @PageableDefault(size = 20, sort = "fullName") Pageable pageable
+) {
+    Long tenantId = TenantContext.getTenantId();
+    return ResponseEntity.ok(PageResponseDto.from(userService.findUsersByRole(tenantId, role, search, pageable)));
+}
 
     /**
      * Use this endpoint for select/dropdown options when the UI needs the full role-filtered list.

--- a/backend/src/main/java/com/team29/kindergarten/modules/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/team29/kindergarten/modules/user/repository/UserRepository.java
@@ -19,10 +19,10 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByEmailAndIdNot(String email, Long id);
 
-    Page<User> findDistinctByTenantIdAndRoles_NameOrderByFullNameAsc(Long tenantId, RoleName roleName, Pageable pageable);
+    Page<User> findDistinctByTenantIdAndRoles_Name(Long tenantId, RoleName roleName, Pageable pageable);
 
-    Page<User> findDistinctByTenantIdAndRoles_NameAndFullNameContainingIgnoreCaseOrderByFullNameAsc(
-        Long tenantId, RoleName roleName, String fullName, Pageable pageable);
+    Page<User> findDistinctByTenantIdAndRoles_NameAndFullNameContainingIgnoreCase(
+    Long tenantId, RoleName roleName, String fullName, Pageable pageable);
 
     List<User> findDistinctByTenantIdAndRoles_NameOrderByFullNameAsc(Long tenantId, RoleName roleName);
 

--- a/backend/src/main/java/com/team29/kindergarten/modules/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/team29/kindergarten/modules/user/repository/UserRepository.java
@@ -21,6 +21,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Page<User> findDistinctByTenantIdAndRoles_NameOrderByFullNameAsc(Long tenantId, RoleName roleName, Pageable pageable);
 
+    Page<User> findDistinctByTenantIdAndRoles_NameAndFullNameContainingIgnoreCaseOrderByFullNameAsc(
+        Long tenantId, RoleName roleName, String fullName, Pageable pageable);
+
     List<User> findDistinctByTenantIdAndRoles_NameOrderByFullNameAsc(Long tenantId, RoleName roleName);
 
     List<User> findAllByIdInAndTenantIdAndRoles_Name(Set<Long> ids, Long tenantId, RoleName roleName);

--- a/backend/src/main/java/com/team29/kindergarten/modules/user/service/UserService.java
+++ b/backend/src/main/java/com/team29/kindergarten/modules/user/service/UserService.java
@@ -35,8 +35,11 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
     private final GroupRepository groupRepository;
 
-    public Page<UserResponseDto> findUsersByRole(Long tenantId, RoleName roleName, Pageable pageable) {
-        Page<User> usersPage = userRepository.findDistinctByTenantIdAndRoles_NameOrderByFullNameAsc(tenantId, roleName, pageable);
+    public Page<UserResponseDto> findUsersByRole(Long tenantId, RoleName roleName, String search, Pageable pageable) {
+    Page<User> usersPage = (search != null && !search.isBlank())
+            ? userRepository.findDistinctByTenantIdAndRoles_NameAndFullNameContainingIgnoreCaseOrderByFullNameAsc(tenantId, roleName, search, pageable)
+            : userRepository.findDistinctByTenantIdAndRoles_NameOrderByFullNameAsc(tenantId, roleName, pageable);
+
         Page<UserResponseDto> responsePage = usersPage.map(userMapper::toUserResponseDto);
 
         if (roleName != RoleName.TEACHER || responsePage.isEmpty()) {

--- a/backend/src/main/java/com/team29/kindergarten/modules/user/service/UserService.java
+++ b/backend/src/main/java/com/team29/kindergarten/modules/user/service/UserService.java
@@ -37,8 +37,8 @@ public class UserService {
 
     public Page<UserResponseDto> findUsersByRole(Long tenantId, RoleName roleName, String search, Pageable pageable) {
     Page<User> usersPage = (search != null && !search.isBlank())
-            ? userRepository.findDistinctByTenantIdAndRoles_NameAndFullNameContainingIgnoreCaseOrderByFullNameAsc(tenantId, roleName, search, pageable)
-            : userRepository.findDistinctByTenantIdAndRoles_NameOrderByFullNameAsc(tenantId, roleName, pageable);
+            ? userRepository.findDistinctByTenantIdAndRoles_NameAndFullNameContainingIgnoreCase(tenantId, roleName, search, pageable)
+            : userRepository.findDistinctByTenantIdAndRoles_Name(tenantId, roleName, pageable);
 
         Page<UserResponseDto> responsePage = usersPage.map(userMapper::toUserResponseDto);
 

--- a/frontend/src/app/(kindergarten-admin)/kindergarten-admin/groups/page.tsx
+++ b/frontend/src/app/(kindergarten-admin)/kindergarten-admin/groups/page.tsx
@@ -30,12 +30,16 @@ export default function KindergartenAdminGroupsPage() {
   const { token, hydrated } = useAuth();
   const [page, setPage] = useState(1);
   const [search, setSearch] = useState("");
+  const [sortField, setSortField] = useState("name");
+  const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc");
   const { groups, groupPage, loading, error, refetch } = useGroups(
     token,
     page - 1,
     10,
     hydrated,
     search,
+    sortField,
+    sortDirection,
   );
   const {
     teachers: availableTeachersForCreate,
@@ -207,6 +211,13 @@ export default function KindergartenAdminGroupsPage() {
               groups={groups}
               onEditAction={(group) => setGroupToEdit(group)}
               onDeleteAction={(group) => setGroupToDelete(group)}
+              sortField={sortField}
+              sortDirection={sortDirection}
+              onSortChange={(field, direction) => {
+                setSortField(field);
+                setSortDirection(direction);
+                setPage(1);
+              }}
             />
             {groupPage && groupPage.totalElements > 0 ? (
               <Typography variant="body2" color="text.secondary" align="center">

--- a/frontend/src/app/(kindergarten-admin)/kindergarten-admin/groups/page.tsx
+++ b/frontend/src/app/(kindergarten-admin)/kindergarten-admin/groups/page.tsx
@@ -5,235 +5,287 @@ import Typography from "@mui/material/Typography";
 import Stack from "@mui/material/Stack";
 import { useState } from "react";
 import type { AlertColor } from "@mui/material";
-import { Button, ConfirmDialog, ErrorState, Pagination, Spinner, Toast } from "@/src/components/ui";
+import TextField from "@mui/material/TextField";
+import {
+  Button,
+  ConfirmDialog,
+  ErrorState,
+  Pagination,
+  Spinner,
+  Toast,
+} from "@/src/components/ui";
 import { useAuth } from "@/src/context/AuthContext";
 import type { Group, UpdateGroupPayload } from "@/src/modules/groups";
-import { createGroup, deleteGroup, GroupFormDialog, GroupsTable, updateGroup, useGroups } from "@/src/modules/groups";
+import {
+  createGroup,
+  deleteGroup,
+  GroupFormDialog,
+  GroupsTable,
+  updateGroup,
+  useGroups,
+} from "@/src/modules/groups";
 import { useAvailableTeacherOptions } from "@/src/modules/teachers";
 
 export default function KindergartenAdminGroupsPage() {
-    const { token, hydrated } = useAuth();
-    const [page, setPage] = useState(1);
-    const { groups, groupPage, loading, error, refetch } = useGroups(token, page - 1, 10, hydrated);
-    const {
-        teachers: availableTeachersForCreate,
-        loading: createTeachersLoading,
-        error: createTeachersError,
-        refetch: refetchCreateTeachers,
-    } = useAvailableTeacherOptions(token, null, hydrated);
-    const [createDialogOpen, setCreateDialogOpen] = useState(false);
-    const [groupToEdit, setGroupToEdit] = useState<Group | null>(null);
-    const [groupToDelete, setGroupToDelete] = useState<Group | null>(null);
-    const [submitMode, setSubmitMode] = useState<"create" | "edit" | null>(null);
-    const [notification, setNotification] = useState<{
-        open: boolean;
-        message: string;
-        severity: AlertColor;
-    } | null>(null);
-    const {
-        teachers: availableTeachersForEdit,
-        loading: editTeachersLoading,
-        error: editTeachersError,
-        refetch: refetchEditTeachers,
-    } = useAvailableTeacherOptions(token, groupToEdit?.id, hydrated && !!groupToEdit);
+  const { token, hydrated } = useAuth();
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState("");
+  const { groups, groupPage, loading, error, refetch } = useGroups(
+    token,
+    page - 1,
+    10,
+    hydrated,
+    search,
+  );
+  const {
+    teachers: availableTeachersForCreate,
+    loading: createTeachersLoading,
+    error: createTeachersError,
+    refetch: refetchCreateTeachers,
+  } = useAvailableTeacherOptions(token, null, hydrated);
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [groupToEdit, setGroupToEdit] = useState<Group | null>(null);
+  const [groupToDelete, setGroupToDelete] = useState<Group | null>(null);
+  const [submitMode, setSubmitMode] = useState<"create" | "edit" | null>(null);
+  const [notification, setNotification] = useState<{
+    open: boolean;
+    message: string;
+    severity: AlertColor;
+  } | null>(null);
+  const {
+    teachers: availableTeachersForEdit,
+    loading: editTeachersLoading,
+    error: editTeachersError,
+    refetch: refetchEditTeachers,
+  } = useAvailableTeacherOptions(
+    token,
+    groupToEdit?.id,
+    hydrated && !!groupToEdit,
+  );
 
-    const refreshGroupData = () => {
-        refetch();
-        refetchCreateTeachers();
-        if (groupToEdit) {
-            refetchEditTeachers();
-        }
-    };
+  const refreshGroupData = () => {
+    refetch();
+    refetchCreateTeachers();
+    if (groupToEdit) {
+      refetchEditTeachers();
+    }
+  };
 
-    const handleCreate = async (payload: UpdateGroupPayload) => {
-        if (!token) {
-            return;
-        }
+  const handleCreate = async (payload: UpdateGroupPayload) => {
+    if (!token) {
+      return;
+    }
 
-        try {
-            setSubmitMode("create");
-            await createGroup(token, payload);
-            refreshGroupData();
-            setCreateDialogOpen(false);
-            setNotification({
-                open: true,
-                message: "Group created successfully",
-                severity: "success",
-            });
-        } catch (err) {
-            console.error(err);
-            const details = err instanceof Error ? err.message : null;
-            setNotification({
-                open: true,
-                message: details ? `Failed to create group: ${details}` : "Failed to create group",
-                severity: "error",
-            });
-        } finally {
-            setSubmitMode(null);
-        }
-    };
+    try {
+      setSubmitMode("create");
+      await createGroup(token, payload);
+      refreshGroupData();
+      setCreateDialogOpen(false);
+      setNotification({
+        open: true,
+        message: "Group created successfully",
+        severity: "success",
+      });
+    } catch (err) {
+      console.error(err);
+      const details = err instanceof Error ? err.message : null;
+      setNotification({
+        open: true,
+        message: details
+          ? `Failed to create group: ${details}`
+          : "Failed to create group",
+        severity: "error",
+      });
+    } finally {
+      setSubmitMode(null);
+    }
+  };
 
-    const handleDelete = async (groupId: number) => {
-        if (!token) {
-            return;
-        }
+  const handleDelete = async (groupId: number) => {
+    if (!token) {
+      return;
+    }
 
-        try {
-            await deleteGroup(groupId, token);
-            refreshGroupData();
-            setGroupToDelete(null);
-            setNotification({
-                open: true,
-                message: "Group deleted successfully",
-                severity: "success",
-            });
-        } catch (err) {
-            console.error(err);
-            const details = err instanceof Error ? err.message : null;
-            setNotification({
-                open: true,
-                message: details ? `Failed to delete group: ${details}` : "Failed to delete group",
-                severity: "error",
-            });
-        }
-    };
+    try {
+      await deleteGroup(groupId, token);
+      refreshGroupData();
+      setGroupToDelete(null);
+      setNotification({
+        open: true,
+        message: "Group deleted successfully",
+        severity: "success",
+      });
+    } catch (err) {
+      console.error(err);
+      const details = err instanceof Error ? err.message : null;
+      setNotification({
+        open: true,
+        message: details
+          ? `Failed to delete group: ${details}`
+          : "Failed to delete group",
+        severity: "error",
+      });
+    }
+  };
 
-    const handleSave = async (payload: UpdateGroupPayload) => {
-        if (!token || !groupToEdit) {
-            return;
-        }
+  const handleSave = async (payload: UpdateGroupPayload) => {
+    if (!token || !groupToEdit) {
+      return;
+    }
 
-        try {
-            setSubmitMode("edit");
-            await updateGroup(groupToEdit.id, token, payload);
-            refreshGroupData();
-            setGroupToEdit(null);
-            setNotification({
-                open: true,
-                message: "Group updated successfully",
-                severity: "success",
-            });
-        } catch (err) {
-            console.error(err);
-            const details = err instanceof Error ? err.message : null;
-            setNotification({
-                open: true,
-                message: details ? `Failed to update group: ${details}` : "Failed to update group",
-                severity: "error",
-            });
-        } finally {
-            setSubmitMode(null);
-        }
-    };
+    try {
+      setSubmitMode("edit");
+      await updateGroup(groupToEdit.id, token, payload);
+      refreshGroupData();
+      setGroupToEdit(null);
+      setNotification({
+        open: true,
+        message: "Group updated successfully",
+        severity: "success",
+      });
+    } catch (err) {
+      console.error(err);
+      const details = err instanceof Error ? err.message : null;
+      setNotification({
+        open: true,
+        message: details
+          ? `Failed to update group: ${details}`
+          : "Failed to update group",
+        severity: "error",
+      });
+    } finally {
+      setSubmitMode(null);
+    }
+  };
 
-    return (
-        <Paper sx={{p: 3, borderRadius: 1}}>
-            <Stack spacing={2}>
-                <Stack direction="row" justifyContent="space-between" alignItems="center">
-                    <Typography variant="h4" fontWeight={700}>
-                        Groups
-                    </Typography>
-                    <Button color="primary" onClick={() => setCreateDialogOpen(true)}>
-                        Add group
-                    </Button>
-                </Stack>
+  return (
+    <Paper sx={{ p: 3, borderRadius: 1 }}>
+      <Stack spacing={2}>
+        <Stack
+          direction="row"
+          justifyContent="space-between"
+          alignItems="center"
+        >
+          <Typography variant="h4" fontWeight={700}>
+            Groups
+          </Typography>
+          <Button color="primary" onClick={() => setCreateDialogOpen(true)}>
+            Add group
+          </Button>
+        </Stack>
 
-                {loading && groups.length === 0 ? (
-                    <Paper sx={{p: 3, borderRadius: 2}}>
-                        <Stack direction="row" spacing={2} alignItems="center">
-                            <Spinner centered={false} size={24}/>
-                            <Typography>Loading groups...</Typography>
-                        </Stack>
-                    </Paper>
-                ) : error ? (
-                    <ErrorState
-                        title="Failed to load groups"
-                        description={error}
-                        actionLabel="Try again"
-                        onAction={() => {
-                            void refetch();
-                        }}
-                    />
-                ) : (
-                    <>
-                        <GroupsTable
-                            groups={groups}
-                            onEditAction={(group) => setGroupToEdit(group)}
-                            onDeleteAction={(group) => setGroupToDelete(group)}
-                        />
-                        {groupPage && groupPage.totalElements > 0 ? (
-                            <Typography variant="body2" color="text.secondary" align="center">
-                                {groupPage.number * groupPage.size + 1}-
-                                {Math.min((groupPage.number + 1) * groupPage.size, groupPage.totalElements)} of{" "}
-                                {groupPage.totalElements}
-                            </Typography>
-                        ) : null}
-                        {(groupPage?.totalPages ?? 0) > 1 ? (
-                            <Pagination
-                                count={groupPage?.totalPages ?? 0}
-                                page={page}
-                                onChange={(_, value) => setPage(value)}
-                            />
-                        ) : null}
-                    </>
-                )}
+        <TextField
+          size="small"
+          placeholder="Search groups..."
+          value={search}
+          onChange={(e) => {
+            setSearch(e.target.value);
+            setPage(1);
+          }}
+          sx={{ width: 280 }}
+        />
 
-                <GroupFormDialog
-                    key={createDialogOpen ? "create-group-open" : "create-group-closed"}
-                    open={createDialogOpen}
-                    title="Add group"
-                    submitLabel="Create"
-                    teachers={availableTeachersForCreate}
-                    teachersLoading={createTeachersLoading}
-                    teachersError={createTeachersError}
-                    loading={submitMode === "create"}
-                    onCloseAction={() => setCreateDialogOpen(false)}
-                    onSubmitAction={handleCreate}
-                />
-
-                <GroupFormDialog
-                    key={groupToEdit ? `edit-group-${groupToEdit.id}` : "edit-group-closed"}
-                    open={!!groupToEdit}
-                    title="Edit group"
-                    submitLabel="Save"
-                    group={groupToEdit}
-                    teachers={availableTeachersForEdit}
-                    teachersLoading={editTeachersLoading}
-                    teachersError={editTeachersError}
-                    loading={submitMode === "edit"}
-                    onCloseAction={() => setGroupToEdit(null)}
-                    onSubmitAction={handleSave}
-                />
-
-                <ConfirmDialog
-                    open={!!groupToDelete}
-                    title="Delete group"
-                    message={
-                        groupToDelete
-                            ? `Are you sure you want to delete "${groupToDelete.name}"?`
-                            : ""
-                    }
-                    confirmLabel="Delete"
-                    cancelLabel="Cancel"
-                    onCancel={() => setGroupToDelete(null)}
-                    onConfirm={() => {
-                        if (groupToDelete) {
-                            void handleDelete(groupToDelete.id);
-                        }
-                    }}
-                />
-
-                <Toast
-                    open={!!notification?.open}
-                    onClose={(_, reason) => {
-                        if (reason !== "clickaway") {
-                            setNotification(null);
-                        }
-                    }}
-                    message={notification?.message ?? ""}
-                    severity={notification?.severity ?? "info"}
-                />
+        {loading && groups.length === 0 ? (
+          <Paper sx={{ p: 3, borderRadius: 2 }}>
+            <Stack direction="row" spacing={2} alignItems="center">
+              <Spinner centered={false} size={24} />
+              <Typography>Loading groups...</Typography>
             </Stack>
-        </Paper>
-    );
+          </Paper>
+        ) : error ? (
+          <ErrorState
+            title="Failed to load groups"
+            description={error}
+            actionLabel="Try again"
+            onAction={() => {
+              void refetch();
+            }}
+          />
+        ) : (
+          <>
+            <GroupsTable
+              groups={groups}
+              onEditAction={(group) => setGroupToEdit(group)}
+              onDeleteAction={(group) => setGroupToDelete(group)}
+            />
+            {groupPage && groupPage.totalElements > 0 ? (
+              <Typography variant="body2" color="text.secondary" align="center">
+                {groupPage.number * groupPage.size + 1}-
+                {Math.min(
+                  (groupPage.number + 1) * groupPage.size,
+                  groupPage.totalElements,
+                )}{" "}
+                of {groupPage.totalElements}
+              </Typography>
+            ) : null}
+            {(groupPage?.totalPages ?? 0) > 1 ? (
+              <Pagination
+                count={groupPage?.totalPages ?? 0}
+                page={page}
+                onChange={(_, value) => setPage(value)}
+              />
+            ) : null}
+          </>
+        )}
+
+        <GroupFormDialog
+          key={createDialogOpen ? "create-group-open" : "create-group-closed"}
+          open={createDialogOpen}
+          title="Add group"
+          submitLabel="Create"
+          teachers={availableTeachersForCreate}
+          teachersLoading={createTeachersLoading}
+          teachersError={createTeachersError}
+          loading={submitMode === "create"}
+          onCloseAction={() => setCreateDialogOpen(false)}
+          onSubmitAction={handleCreate}
+        />
+
+        <GroupFormDialog
+          key={
+            groupToEdit ? `edit-group-${groupToEdit.id}` : "edit-group-closed"
+          }
+          open={!!groupToEdit}
+          title="Edit group"
+          submitLabel="Save"
+          group={groupToEdit}
+          teachers={availableTeachersForEdit}
+          teachersLoading={editTeachersLoading}
+          teachersError={editTeachersError}
+          loading={submitMode === "edit"}
+          onCloseAction={() => setGroupToEdit(null)}
+          onSubmitAction={handleSave}
+        />
+
+        <ConfirmDialog
+          open={!!groupToDelete}
+          title="Delete group"
+          message={
+            groupToDelete
+              ? `Are you sure you want to delete "${groupToDelete.name}"?`
+              : ""
+          }
+          confirmLabel="Delete"
+          cancelLabel="Cancel"
+          onCancel={() => setGroupToDelete(null)}
+          onConfirm={() => {
+            if (groupToDelete) {
+              void handleDelete(groupToDelete.id);
+            }
+          }}
+        />
+
+        <Toast
+          open={!!notification?.open}
+          onClose={(_, reason) => {
+            if (reason !== "clickaway") {
+              setNotification(null);
+            }
+          }}
+          message={notification?.message ?? ""}
+          severity={notification?.severity ?? "info"}
+        />
+      </Stack>
+    </Paper>
+  );
 }

--- a/frontend/src/app/(kindergarten-admin)/kindergarten-admin/teachers/page.tsx
+++ b/frontend/src/app/(kindergarten-admin)/kindergarten-admin/teachers/page.tsx
@@ -32,12 +32,16 @@ export default function KindergartenAdminTeachersPage() {
   const { token, hydrated } = useAuth();
   const [page, setPage] = useState(1);
   const [search, setSearch] = useState("");
+  const [sortField, setSortField] = useState("fullName");
+  const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc");
   const { teachers, teacherPage, loading, error, refetch } = useTeachers(
     token,
     page - 1,
     10,
     hydrated,
     search,
+    sortField,
+    sortDirection,
   );
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [teacherToEdit, setTeacherToEdit] = useState<Teacher | null>(null);
@@ -181,6 +185,13 @@ export default function KindergartenAdminTeachersPage() {
               teachers={teachers}
               onEditAction={(teacher) => setTeacherToEdit(teacher)}
               onDeleteAction={(teacher) => setTeacherToDelete(teacher)}
+              sortField={sortField}
+              sortDirection={sortDirection}
+              onSortChange={(field, direction) => {
+                setSortField(field);
+                setSortDirection(direction);
+                setPage(1);
+              }}
             />
             {teacherPage && teacherPage.totalElements > 0 ? (
               <Typography variant="body2" color="text.secondary" align="center">

--- a/frontend/src/app/(kindergarten-admin)/kindergarten-admin/teachers/page.tsx
+++ b/frontend/src/app/(kindergarten-admin)/kindergarten-admin/teachers/page.tsx
@@ -3,218 +3,263 @@
 import Paper from "@mui/material/Paper";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
+import TextField from "@mui/material/TextField";
 import type { AlertColor } from "@mui/material";
 import { useState } from "react";
-import { Button, ConfirmDialog, ErrorState, Pagination, Spinner, Toast } from "@/src/components/ui";
+import {
+  Button,
+  ConfirmDialog,
+  ErrorState,
+  Pagination,
+  Spinner,
+  Toast,
+} from "@/src/components/ui";
 import { useAuth } from "@/src/context/AuthContext";
-import { createTeacherUser, deleteTeacherUser, updateTeacherUser } from "@/src/modules/users";
+import {
+  createTeacherUser,
+  deleteTeacherUser,
+  updateTeacherUser,
+} from "@/src/modules/users";
 import type { Teacher } from "@/src/modules/teachers";
-import { TeacherFormDialog, type TeacherFormValues, TeachersTable, useTeachers } from "@/src/modules/teachers";
+import {
+  TeacherFormDialog,
+  type TeacherFormValues,
+  TeachersTable,
+  useTeachers,
+} from "@/src/modules/teachers";
 
 export default function KindergartenAdminTeachersPage() {
-    const { token, hydrated } = useAuth();
-    const [page, setPage] = useState(1);
-    const { teachers, teacherPage, loading, error, refetch } = useTeachers(token, page - 1, 10, hydrated);
-    const [createDialogOpen, setCreateDialogOpen] = useState(false);
-    const [teacherToEdit, setTeacherToEdit] = useState<Teacher | null>(null);
-    const [teacherToDelete, setTeacherToDelete] = useState<Teacher | null>(null);
-    const [submitMode, setSubmitMode] = useState<"create" | "edit" | null>(null);
-    const [notification, setNotification] = useState<{
-        open: boolean;
-        message: string;
-        severity: AlertColor;
-    } | null>(null);
+  const { token, hydrated } = useAuth();
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState("");
+  const { teachers, teacherPage, loading, error, refetch } = useTeachers(
+    token,
+    page - 1,
+    10,
+    hydrated,
+    search,
+  );
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [teacherToEdit, setTeacherToEdit] = useState<Teacher | null>(null);
+  const [teacherToDelete, setTeacherToDelete] = useState<Teacher | null>(null);
+  const [submitMode, setSubmitMode] = useState<"create" | "edit" | null>(null);
+  const [notification, setNotification] = useState<{
+    open: boolean;
+    message: string;
+    severity: AlertColor;
+  } | null>(null);
 
-    const handleCreate = async (values: TeacherFormValues) => {
-        if (!token || !values.password) {
-            return;
-        }
+  const handleCreate = async (values: TeacherFormValues) => {
+    if (!token || !values.password) return;
+    try {
+      setSubmitMode("create");
+      await createTeacherUser(token, {
+        fullName: values.fullName,
+        email: values.email,
+        password: values.password,
+      });
+      refetch();
+      setCreateDialogOpen(false);
+      setNotification({
+        open: true,
+        message: "Teacher created successfully",
+        severity: "success",
+      });
+    } catch (err) {
+      console.error(err);
+      const details = err instanceof Error ? err.message : null;
+      setNotification({
+        open: true,
+        message: details
+          ? `Failed to create teacher: ${details}`
+          : "Failed to create teacher",
+        severity: "error",
+      });
+    } finally {
+      setSubmitMode(null);
+    }
+  };
 
-        try {
-            setSubmitMode("create");
-            await createTeacherUser(token, {
-                fullName: values.fullName,
-                email: values.email,
-                password: values.password,
-            });
-            refetch();
-            setCreateDialogOpen(false);
-            setNotification({
-                open: true,
-                message: "Teacher created successfully",
-                severity: "success",
-            });
-        } catch (err) {
-            console.error(err);
-            const details = err instanceof Error ? err.message : null;
-            setNotification({
-                open: true,
-                message: details ? `Failed to create teacher: ${details}` : "Failed to create teacher",
-                severity: "error",
-            });
-        } finally {
-            setSubmitMode(null);
-        }
-    };
+  const handleEdit = async (values: TeacherFormValues) => {
+    if (!token || !teacherToEdit) return;
+    try {
+      setSubmitMode("edit");
+      await updateTeacherUser(teacherToEdit.id, token, {
+        fullName: values.fullName,
+        email: values.email,
+        password: values.password,
+      });
+      refetch();
+      setTeacherToEdit(null);
+      setNotification({
+        open: true,
+        message: "Teacher updated successfully",
+        severity: "success",
+      });
+    } catch (err) {
+      console.error(err);
+      const details = err instanceof Error ? err.message : null;
+      setNotification({
+        open: true,
+        message: details
+          ? `Failed to update teacher: ${details}`
+          : "Failed to update teacher",
+        severity: "error",
+      });
+    } finally {
+      setSubmitMode(null);
+    }
+  };
 
-    const handleEdit = async (values: TeacherFormValues) => {
-        if (!token || !teacherToEdit) {
-            return;
-        }
+  const handleDelete = async (teacherId: number) => {
+    if (!token) return;
+    try {
+      await deleteTeacherUser(teacherId, token);
+      refetch();
+      setTeacherToDelete(null);
+      setNotification({
+        open: true,
+        message: "Teacher deleted successfully",
+        severity: "success",
+      });
+    } catch (err) {
+      console.error(err);
+      const details = err instanceof Error ? err.message : null;
+      setNotification({
+        open: true,
+        message: details
+          ? `Failed to delete teacher: ${details}`
+          : "Failed to delete teacher",
+        severity: "error",
+      });
+    }
+  };
 
-        try {
-            setSubmitMode("edit");
-            await updateTeacherUser(teacherToEdit.id, token, {
-                fullName: values.fullName,
-                email: values.email,
-                password: values.password,
-            });
-            refetch();
-            setTeacherToEdit(null);
-            setNotification({
-                open: true,
-                message: "Teacher updated successfully",
-                severity: "success",
-            });
-        } catch (err) {
-            console.error(err);
-            const details = err instanceof Error ? err.message : null;
-            setNotification({
-                open: true,
-                message: details ? `Failed to update teacher: ${details}` : "Failed to update teacher",
-                severity: "error",
-            });
-        } finally {
-            setSubmitMode(null);
-        }
-    };
+  return (
+    <Paper sx={{ p: 3, borderRadius: 1 }}>
+      <Stack spacing={2}>
+        <Stack
+          direction="row"
+          justifyContent="space-between"
+          alignItems="center"
+        >
+          <Typography variant="h4" fontWeight={700}>
+            Teachers
+          </Typography>
+          <Button color="primary" onClick={() => setCreateDialogOpen(true)}>
+            Add teacher
+          </Button>
+        </Stack>
 
-    const handleDelete = async (teacherId: number) => {
-        if (!token) {
-            return;
-        }
+        <TextField
+          size="small"
+          placeholder="Search teachers..."
+          value={search}
+          onChange={(e) => {
+            setSearch(e.target.value);
+            setPage(1);
+          }}
+          sx={{ width: 280 }}
+        />
 
-        try {
-            await deleteTeacherUser(teacherId, token);
-            refetch();
-            setTeacherToDelete(null);
-            setNotification({
-                open: true,
-                message: "Teacher deleted successfully",
-                severity: "success",
-            });
-        } catch (err) {
-            console.error(err);
-            const details = err instanceof Error ? err.message : null;
-            setNotification({
-                open: true,
-                message: details ? `Failed to delete teacher: ${details}` : "Failed to delete teacher",
-                severity: "error",
-            });
-        }
-    };
-
-    return (
-        <Paper sx={{ p: 3, borderRadius: 1 }}>
-            <Stack spacing={2}>
-                <Stack direction="row" justifyContent="space-between" alignItems="center">
-                    <Typography variant="h4" fontWeight={700}>
-                        Teachers
-                    </Typography>
-                    <Button color="primary" onClick={() => setCreateDialogOpen(true)}>
-                        Add teacher
-                    </Button>
-                </Stack>
-
-                {loading && teachers.length === 0 ? (
-                    <Paper sx={{ p: 3, borderRadius: 2 }}>
-                        <Stack direction="row" spacing={2} alignItems="center">
-                            <Spinner centered={false} size={24} />
-                            <Typography>Loading teachers...</Typography>
-                        </Stack>
-                    </Paper>
-                ) : error ? (
-                    <ErrorState
-                        title="Failed to load teachers"
-                        description={error}
-                        actionLabel={undefined}
-                    />
-                ) : (
-                    <>
-                        <TeachersTable
-                            teachers={teachers}
-                            onEditAction={(teacher) => setTeacherToEdit(teacher)}
-                            onDeleteAction={(teacher) => setTeacherToDelete(teacher)}
-                        />
-                        {teacherPage && teacherPage.totalElements > 0 ? (
-                            <Typography variant="body2" color="text.secondary" align="center">
-                                {teacherPage.number * teacherPage.size + 1}-
-                                {Math.min((teacherPage.number + 1) * teacherPage.size, teacherPage.totalElements)} of{" "}
-                                {teacherPage.totalElements}
-                            </Typography>
-                        ) : null}
-                        {(teacherPage?.totalPages ?? 0) > 1 ? (
-                            <Pagination
-                                count={teacherPage?.totalPages ?? 0}
-                                page={page}
-                                onChange={(_, value) => setPage(value)}
-                            />
-                        ) : null}
-                    </>
-                )}
-
-                <TeacherFormDialog
-                    key={createDialogOpen ? "create-teacher-open" : "create-teacher-closed"}
-                    open={createDialogOpen}
-                    title="Add teacher"
-                    submitLabel="Create"
-                    loading={submitMode === "create"}
-                    requirePassword
-                    onCloseAction={() => setCreateDialogOpen(false)}
-                    onSubmitAction={handleCreate}
-                />
-
-                <TeacherFormDialog
-                    key={teacherToEdit ? `edit-teacher-${teacherToEdit.id}` : "edit-teacher-closed"}
-                    open={!!teacherToEdit}
-                    title="Edit teacher"
-                    submitLabel="Save"
-                    teacher={teacherToEdit}
-                    loading={submitMode === "edit"}
-                    requirePassword={false}
-                    onCloseAction={() => setTeacherToEdit(null)}
-                    onSubmitAction={handleEdit}
-                />
-
-                <ConfirmDialog
-                    open={!!teacherToDelete}
-                    title="Delete teacher"
-                    message={
-                        teacherToDelete
-                            ? `Are you sure you want to delete "${teacherToDelete.fullName}"?`
-                            : ""
-                    }
-                    confirmLabel="Delete"
-                    cancelLabel="Cancel"
-                    onCancel={() => setTeacherToDelete(null)}
-                    onConfirm={() => {
-                        if (teacherToDelete) {
-                            void handleDelete(teacherToDelete.id);
-                        }
-                    }}
-                />
-
-                <Toast
-                    open={!!notification?.open}
-                    onClose={(_, reason) => {
-                        if (reason !== "clickaway") {
-                            setNotification(null);
-                        }
-                    }}
-                    message={notification?.message ?? ""}
-                    severity={notification?.severity ?? "info"}
-                />
+        {loading && teachers.length === 0 ? (
+          <Paper sx={{ p: 3, borderRadius: 2 }}>
+            <Stack direction="row" spacing={2} alignItems="center">
+              <Spinner centered={false} size={24} />
+              <Typography>Loading teachers...</Typography>
             </Stack>
-        </Paper>
-    );
+          </Paper>
+        ) : error ? (
+          <ErrorState
+            title="Failed to load teachers"
+            description={error}
+            actionLabel={undefined}
+          />
+        ) : (
+          <>
+            <TeachersTable
+              teachers={teachers}
+              onEditAction={(teacher) => setTeacherToEdit(teacher)}
+              onDeleteAction={(teacher) => setTeacherToDelete(teacher)}
+            />
+            {teacherPage && teacherPage.totalElements > 0 ? (
+              <Typography variant="body2" color="text.secondary" align="center">
+                {teacherPage.number * teacherPage.size + 1}-
+                {Math.min(
+                  (teacherPage.number + 1) * teacherPage.size,
+                  teacherPage.totalElements,
+                )}{" "}
+                of {teacherPage.totalElements}
+              </Typography>
+            ) : null}
+            {(teacherPage?.totalPages ?? 0) > 1 ? (
+              <Pagination
+                count={teacherPage?.totalPages ?? 0}
+                page={page}
+                onChange={(_, value) => setPage(value)}
+              />
+            ) : null}
+          </>
+        )}
+
+        <TeacherFormDialog
+          key={
+            createDialogOpen ? "create-teacher-open" : "create-teacher-closed"
+          }
+          open={createDialogOpen}
+          title="Add teacher"
+          submitLabel="Create"
+          loading={submitMode === "create"}
+          requirePassword
+          onCloseAction={() => setCreateDialogOpen(false)}
+          onSubmitAction={handleCreate}
+        />
+
+        <TeacherFormDialog
+          key={
+            teacherToEdit
+              ? `edit-teacher-${teacherToEdit.id}`
+              : "edit-teacher-closed"
+          }
+          open={!!teacherToEdit}
+          title="Edit teacher"
+          submitLabel="Save"
+          teacher={teacherToEdit}
+          loading={submitMode === "edit"}
+          requirePassword={false}
+          onCloseAction={() => setTeacherToEdit(null)}
+          onSubmitAction={handleEdit}
+        />
+
+        <ConfirmDialog
+          open={!!teacherToDelete}
+          title="Delete teacher"
+          message={
+            teacherToDelete
+              ? `Are you sure you want to delete "${teacherToDelete.fullName}"?`
+              : ""
+          }
+          confirmLabel="Delete"
+          cancelLabel="Cancel"
+          onCancel={() => setTeacherToDelete(null)}
+          onConfirm={() => {
+            if (teacherToDelete) {
+              void handleDelete(teacherToDelete.id);
+            }
+          }}
+        />
+
+        <Toast
+          open={!!notification?.open}
+          onClose={(_, reason) => {
+            if (reason !== "clickaway") {
+              setNotification(null);
+            }
+          }}
+          message={notification?.message ?? ""}
+          severity={notification?.severity ?? "info"}
+        />
+      </Stack>
+    </Paper>
+  );
 }

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -77,7 +77,7 @@ export { default as ConfirmDialog } from "./confirm-dialog";
 export type { ConfirmDialogProps } from "./confirm-dialog";
 
 export { default as Table } from "./table";
-export type { TableProps, TableColumn } from "./table";
+export type { TableProps, TableColumn, SortDirection } from "./table";
 
 export { default as TableRowActions } from "./table-row-actions";
 export type { TableRowActionsProps } from "./table-row-actions";

--- a/frontend/src/components/ui/table.tsx
+++ b/frontend/src/components/ui/table.tsx
@@ -9,13 +9,18 @@ import {
   TableContainer,
   TableHead,
   TableRow,
+  TableSortLabel,
 } from "@mui/material";
+
+export type SortDirection = "asc" | "desc";
 
 export type TableColumn<T> = {
   key: keyof T | string;
   label: ReactNode;
   align?: "left" | "right" | "center";
   render?: (row: T) => ReactNode;
+  sortable?: boolean;
+  sortKey?: string;
 };
 
 export type TableProps<T> = {
@@ -23,9 +28,27 @@ export type TableProps<T> = {
   rows: T[];
   rowKey?: (row: T, index: number) => string;
   size?: "small" | "medium";
+  sortField?: string;
+  sortDirection?: SortDirection;
+  onSortChange?: (field: string, direction: SortDirection) => void;
 };
 
-export default function Table<T>({ columns, rows, rowKey, size = "small" }: TableProps<T>) {
+export default function Table<T>({
+  columns,
+  rows,
+  rowKey,
+  size = "small",
+  sortField,
+  sortDirection = "asc",
+  onSortChange,
+}: TableProps<T>) {
+  const handleSort = (field: string) => {
+    if (!onSortChange) return;
+    const newDirection =
+      sortField === field && sortDirection === "asc" ? "desc" : "asc";
+    onSortChange(field, newDirection);
+  };
+
   return (
     <TableContainer component={Paper} variant="outlined">
       <MuiTable size={size}>
@@ -33,7 +56,25 @@ export default function Table<T>({ columns, rows, rowKey, size = "small" }: Tabl
           <TableRow>
             {columns.map((column) => (
               <TableCell align={column.align} key={String(column.key)}>
-                {column.label}
+                {column.sortable && onSortChange ? (
+                  <TableSortLabel
+                    active={
+                      sortField === (column.sortKey ?? String(column.key))
+                    }
+                    direction={
+                      sortField === (column.sortKey ?? String(column.key))
+                        ? sortDirection
+                        : "asc"
+                    }
+                    onClick={() =>
+                      handleSort(column.sortKey ?? String(column.key))
+                    }
+                  >
+                    {column.label}
+                  </TableSortLabel>
+                ) : (
+                  column.label
+                )}
               </TableCell>
             ))}
           </TableRow>
@@ -43,7 +84,9 @@ export default function Table<T>({ columns, rows, rowKey, size = "small" }: Tabl
             <TableRow hover key={rowKey?.(row, index) ?? String(index)}>
               {columns.map((column) => (
                 <TableCell align={column.align} key={String(column.key)}>
-                  {column.render ? column.render(row) : (row as Record<string, ReactNode>)[String(column.key)]}
+                  {column.render
+                    ? column.render(row)
+                    : (row as Record<string, ReactNode>)[String(column.key)]}
                 </TableCell>
               ))}
             </TableRow>

--- a/frontend/src/modules/groups/api/getGroups.ts
+++ b/frontend/src/modules/groups/api/getGroups.ts
@@ -2,17 +2,33 @@ import type { Group } from "../model/group";
 import type { PageResponse } from "@/src/shared/model/page";
 import { API_URL } from "@/src/services/api";
 
-export async function getGroups(token: string, page: number, size = 10): Promise<PageResponse<Group>> {
-    const response = await fetch(`${API_URL}/api/v1/groups?page=${page}&size=${size}`, {
-        headers: {
-            Authorization: `Bearer ${token}`,
-        },
-        cache: "no-store",
-    });
+export async function getGroups(
+  token: string,
+  page: number,
+  size = 10,
+  search?: string,
+): Promise<PageResponse<Group>> {
+  const params = new URLSearchParams({
+    page: String(page),
+    size: String(size),
+  });
+  if (search && search.trim()) {
+    params.set("search", search.trim());
+  }
 
-    if (!response.ok) {
-        throw new Error("Failed to fetch groups");
-    }
+  const response = await fetch(
+    `${API_URL}/api/v1/groups?${params.toString()}`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      cache: "no-store",
+    },
+  );
 
-    return response.json();
+  if (!response.ok) {
+    throw new Error("Failed to fetch groups");
+  }
+
+  return response.json();
 }

--- a/frontend/src/modules/groups/api/getGroups.ts
+++ b/frontend/src/modules/groups/api/getGroups.ts
@@ -7,10 +7,13 @@ export async function getGroups(
   page: number,
   size = 10,
   search?: string,
+  sortField = "name",
+  sortDirection = "asc",
 ): Promise<PageResponse<Group>> {
   const params = new URLSearchParams({
     page: String(page),
     size: String(size),
+    sort: `${sortField},${sortDirection}`,
   });
   if (search && search.trim()) {
     params.set("search", search.trim());

--- a/frontend/src/modules/groups/hooks/useGroups.ts
+++ b/frontend/src/modules/groups/hooks/useGroups.ts
@@ -6,104 +6,114 @@ import { getGroups } from "../api/getGroups";
 import { getGroupOptions } from "../api/getGroupOptions";
 import type { Group } from "../model/group";
 
-export function useGroups(token: string | null, page: number, size = 10, enabled = true) {
-    const [groupPage, setGroupPage] = useState<PageResponse<Group> | null>(null);
-    const [groups, setGroups] = useState<Group[]>([]);
-    const [loading, setLoading] = useState(false);
-    const [error, setError] = useState<string | null>(null);
-    const [reloadKey, setReloadKey] = useState(0);
+export function useGroups(
+  token: string | null,
+  page: number,
+  size = 10,
+  enabled = true,
+  search = "",
+) {
+  const [groupPage, setGroupPage] = useState<PageResponse<Group> | null>(null);
+  const [groups, setGroups] = useState<Group[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
 
-    useEffect(() => {
-        if (!enabled || !token) {
-            return;
+  useEffect(() => {
+    if (!enabled || !token) {
+      return;
+    }
+    const resolvedToken = token;
+
+    let cancelled = false;
+
+    async function loadGroups() {
+      try {
+        setLoading(true);
+        setError(null);
+        const data = await getGroups(resolvedToken, page, size, search);
+
+        if (!cancelled) {
+          setGroupPage(data);
+          setGroups(data.content);
         }
-        const resolvedToken = token;
-
-        let cancelled = false;
-
-        async function loadGroups() {
-            try {
-                setLoading(true);
-                setError(null);
-                const data = await getGroups(resolvedToken, page, size);
-
-                if (!cancelled) {
-                    setGroupPage(data);
-                    setGroups(data.content);
-                }
-            } catch (err) {
-                if (!cancelled) {
-                    setError(err instanceof Error ? err.message : "Failed to load groups");
-                }
-            } finally {
-                if (!cancelled) {
-                    setLoading(false);
-                }
-            }
+      } catch (err) {
+        if (!cancelled) {
+          setError(
+            err instanceof Error ? err.message : "Failed to load groups",
+          );
         }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
 
-        void loadGroups();
+    void loadGroups();
 
-        return () => {
-            cancelled = true;
-        };
-    }, [enabled, page, reloadKey, size, token]);
-
-    return {
-        groups,
-        groupPage,
-        loading,
-        error,
-        setGroups,
-        refetch: () => setReloadKey((currentValue) => currentValue + 1),
+    return () => {
+      cancelled = true;
     };
+  }, [enabled, page, reloadKey, search, size, token]);
+
+  return {
+    groups,
+    groupPage,
+    loading,
+    error,
+    setGroups,
+    refetch: () => setReloadKey((currentValue) => currentValue + 1),
+  };
 }
 
 export function useGroupOptions(token: string | null, enabled = true) {
-    const [groups, setGroups] = useState<Group[]>([]);
-    const [loading, setLoading] = useState(false);
-    const [error, setError] = useState<string | null>(null);
-    const [reloadKey, setReloadKey] = useState(0);
+  const [groups, setGroups] = useState<Group[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
 
-    useEffect(() => {
-        if (!enabled || !token) {
-            return;
+  useEffect(() => {
+    if (!enabled || !token) {
+      return;
+    }
+
+    const resolvedToken = token;
+    let cancelled = false;
+
+    async function loadGroupOptions() {
+      try {
+        setLoading(true);
+        setError(null);
+        const data = await getGroupOptions(resolvedToken);
+
+        if (!cancelled) {
+          setGroups(data);
         }
-
-        const resolvedToken = token;
-        let cancelled = false;
-
-        async function loadGroupOptions() {
-            try {
-                setLoading(true);
-                setError(null);
-                const data = await getGroupOptions(resolvedToken);
-
-                if (!cancelled) {
-                    setGroups(data);
-                }
-            } catch (err) {
-                if (!cancelled) {
-                    setError(err instanceof Error ? err.message : "Failed to load group options");
-                }
-            } finally {
-                if (!cancelled) {
-                    setLoading(false);
-                }
-            }
+      } catch (err) {
+        if (!cancelled) {
+          setError(
+            err instanceof Error ? err.message : "Failed to load group options",
+          );
         }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
 
-        void loadGroupOptions();
+    void loadGroupOptions();
 
-        return () => {
-            cancelled = true;
-        };
-    }, [enabled, reloadKey, token]);
-
-    return {
-        groups,
-        loading,
-        error,
-        refetch: () => setReloadKey((currentValue) => currentValue + 1),
+    return () => {
+      cancelled = true;
     };
+  }, [enabled, reloadKey, token]);
+
+  return {
+    groups,
+    loading,
+    error,
+    refetch: () => setReloadKey((currentValue) => currentValue + 1),
+  };
 }

--- a/frontend/src/modules/groups/hooks/useGroups.ts
+++ b/frontend/src/modules/groups/hooks/useGroups.ts
@@ -12,6 +12,8 @@ export function useGroups(
   size = 10,
   enabled = true,
   search = "",
+  sortField = "name",
+  sortDirection: "asc" | "desc" = "asc",
 ) {
   const [groupPage, setGroupPage] = useState<PageResponse<Group> | null>(null);
   const [groups, setGroups] = useState<Group[]>([]);
@@ -31,8 +33,14 @@ export function useGroups(
       try {
         setLoading(true);
         setError(null);
-        const data = await getGroups(resolvedToken, page, size, search);
-
+        const data = await getGroups(
+          resolvedToken,
+          page,
+          size,
+          search,
+          sortField,
+          sortDirection,
+        );
         if (!cancelled) {
           setGroupPage(data);
           setGroups(data.content);
@@ -55,7 +63,7 @@ export function useGroups(
     return () => {
       cancelled = true;
     };
-  }, [enabled, page, reloadKey, search, size, token]);
+  }, [enabled, page, reloadKey, search, size, sortDirection, sortField, token]);
 
   return {
     groups,

--- a/frontend/src/modules/groups/ui/GroupsTable.tsx
+++ b/frontend/src/modules/groups/ui/GroupsTable.tsx
@@ -1,59 +1,74 @@
 "use client";
 
 import { EmptyState, Table, TableRowActions } from "@/src/components/ui";
-import type { TableColumn } from "@/src/components/ui";
+import type { TableColumn, SortDirection } from "@/src/components/ui";
 import { formatFullName } from "@/src/shared/utils/formatPersonName";
 import type { Group } from "../model/group";
 
 type GroupsTableProps = {
-    groups: Group[];
-    onEditAction?: (group: Group) => void;
-    onDeleteAction?: (group: Group) => void;
+  groups: Group[];
+  onEditAction?: (group: Group) => void;
+  onDeleteAction?: (group: Group) => void;
+  sortField?: string;
+  sortDirection?: SortDirection;
+  onSortChange?: (field: string, direction: SortDirection) => void;
 };
 
-export default function GroupsTable({ groups, onEditAction, onDeleteAction }: GroupsTableProps) {
-    if (groups.length === 0) {
-        return (
-            <EmptyState
-                title="No groups found"
-                description="Create the first group to start organizing teachers into groups."
-            />
-        );
-    }
-
-    const columns: TableColumn<Group>[] = [
-        { key: "name", label: "Name" },
-        {
-            key: "ageRange",
-            label: "Age Range",
-            render: (group) => group.ageRange ?? "-",
-        },
-        {
-            key: "teacher",
-            label: "Teacher",
-            render: (group) =>
-                group.teacher
-                    ? formatFullName(group.teacher.fullName)
-                    : "-",
-        },
-        {
-            key: "actions",
-            label: "Actions",
-            align: "right",
-            render: (group) => (
-                <TableRowActions
-                    onEditAction={onEditAction ? () => onEditAction(group) : undefined}
-                    onDeleteAction={onDeleteAction ? () => onDeleteAction(group) : undefined}
-                />
-            ),
-        },
-    ];
-
+export default function GroupsTable({
+  groups,
+  onEditAction,
+  onDeleteAction,
+  sortField,
+  sortDirection,
+  onSortChange,
+}: GroupsTableProps) {
+  if (groups.length === 0) {
     return (
-        <Table
-            columns={columns}
-            rows={groups}
-            rowKey={(group) => String(group.id)}
-        />
+      <EmptyState
+        title="No groups found"
+        description="Create the first group to start organizing teachers into groups."
+      />
     );
+  }
+
+  const columns: TableColumn<Group>[] = [
+    { key: "name", label: "Name", sortable: true, sortKey: "name" },
+    {
+      key: "ageRange",
+      label: "Age Range",
+      sortable: true,
+      sortKey: "ageRange",
+      render: (group) => group.ageRange ?? "-",
+    },
+    {
+      key: "teacher",
+      label: "Teacher",
+      render: (group) =>
+        group.teacher ? formatFullName(group.teacher.fullName) : "-",
+    },
+    {
+      key: "actions",
+      label: "Actions",
+      align: "right",
+      render: (group) => (
+        <TableRowActions
+          onEditAction={onEditAction ? () => onEditAction(group) : undefined}
+          onDeleteAction={
+            onDeleteAction ? () => onDeleteAction(group) : undefined
+          }
+        />
+      ),
+    },
+  ];
+
+  return (
+    <Table
+      columns={columns}
+      rows={groups}
+      rowKey={(group) => String(group.id)}
+      sortField={sortField}
+      sortDirection={sortDirection}
+      onSortChange={onSortChange}
+    />
+  );
 }

--- a/frontend/src/modules/teachers/hooks/useTeachers.ts
+++ b/frontend/src/modules/teachers/hooks/useTeachers.ts
@@ -6,22 +6,22 @@ import { API_URL } from "@/src/services/api";
 import { parseApiError } from "@/src/shared/utils/parseApiError";
 import type { User } from "@/src/modules/users";
 
-export function useTeachers(token: string | null, page: number, size = 10, enabled = true) {
-    const {
-        users: teachers,
-        userPage: teacherPage,
-        loading,
-        error,
-        refetch,
-    } = useUsersByRole(
-        token,
-        "TEACHER",
-        page,
-        size,
-        enabled,
-    );
+export function useTeachers(
+  token: string | null,
+  page: number,
+  size = 10,
+  enabled = true,
+  search = "",
+) {
+  const {
+    users: teachers,
+    userPage: teacherPage,
+    loading,
+    error,
+    refetch,
+  } = useUsersByRole(token, "TEACHER", page, size, enabled, search);
 
-    return { teachers, teacherPage, loading, error, refetch };
+  return { teachers, teacherPage, loading, error, refetch };
 }
 
 export function useAvailableTeacherOptions(token: string | null, groupId?: number | null, enabled = true) {

--- a/frontend/src/modules/teachers/hooks/useTeachers.ts
+++ b/frontend/src/modules/teachers/hooks/useTeachers.ts
@@ -12,6 +12,8 @@ export function useTeachers(
   size = 10,
   enabled = true,
   search = "",
+  sortField = "fullName",
+  sortDirection: "asc" | "desc" = "asc",
 ) {
   const {
     users: teachers,
@@ -19,75 +21,97 @@ export function useTeachers(
     loading,
     error,
     refetch,
-  } = useUsersByRole(token, "TEACHER", page, size, enabled, search);
+  } = useUsersByRole(
+    token,
+    "TEACHER",
+    page,
+    size,
+    enabled,
+    search,
+    sortField,
+    sortDirection,
+  );
 
   return { teachers, teacherPage, loading, error, refetch };
 }
 
-export function useAvailableTeacherOptions(token: string | null, groupId?: number | null, enabled = true) {
-    const [teachers, setTeachers] = useState<User[]>([]);
-    const [loading, setLoading] = useState(false);
-    const [error, setError] = useState<string | null>(null);
-    const [reloadKey, setReloadKey] = useState(0);
+export function useAvailableTeacherOptions(
+  token: string | null,
+  groupId?: number | null,
+  enabled = true,
+) {
+  const [teachers, setTeachers] = useState<User[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
 
-    useEffect(() => {
-        if (!enabled || !token) {
-            return;
+  useEffect(() => {
+    if (!enabled || !token) {
+      return;
+    }
+
+    const resolvedToken = token;
+    let cancelled = false;
+
+    async function loadAssignableTeachers() {
+      try {
+        setLoading(true);
+        setError(null);
+        const params = new URLSearchParams();
+        if (groupId != null) {
+          params.set("groupId", String(groupId));
         }
 
-        const resolvedToken = token;
-        let cancelled = false;
+        const response = await fetch(
+          `${API_URL}/api/v1/users/teachers/available-options${params.size ? `?${params.toString()}` : ""}`,
+          {
+            headers: {
+              Authorization: `Bearer ${resolvedToken}`,
+            },
+            cache: "no-store",
+          },
+        );
 
-        async function loadAssignableTeachers() {
-            try {
-                setLoading(true);
-                setError(null);
-                const params = new URLSearchParams();
-                if (groupId != null) {
-                    params.set("groupId", String(groupId));
-                }
-
-                const response = await fetch(
-                    `${API_URL}/api/v1/users/teachers/available-options${params.size ? `?${params.toString()}` : ""}`,
-                    {
-                        headers: {
-                            Authorization: `Bearer ${resolvedToken}`,
-                        },
-                        cache: "no-store",
-                    },
-                );
-
-                if (!response.ok) {
-                    throw new Error(await parseApiError(response, "Failed to fetch assignable teachers"));
-                }
-
-                const data = (await response.json()) as User[];
-
-                if (!cancelled) {
-                    setTeachers(data);
-                }
-            } catch (err) {
-                if (!cancelled) {
-                    setError(err instanceof Error ? err.message : "Failed to fetch assignable teachers");
-                }
-            } finally {
-                if (!cancelled) {
-                    setLoading(false);
-                }
-            }
+        if (!response.ok) {
+          throw new Error(
+            await parseApiError(
+              response,
+              "Failed to fetch assignable teachers",
+            ),
+          );
         }
 
-        void loadAssignableTeachers();
+        const data = (await response.json()) as User[];
 
-        return () => {
-            cancelled = true;
-        };
-    }, [enabled, groupId, reloadKey, token]);
+        if (!cancelled) {
+          setTeachers(data);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(
+            err instanceof Error
+              ? err.message
+              : "Failed to fetch assignable teachers",
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
 
-    return {
-        teachers,
-        loading,
-        error,
-        refetch: () => setReloadKey((currentValue) => currentValue + 1),
+    void loadAssignableTeachers();
+
+    return () => {
+      cancelled = true;
     };
+  }, [enabled, groupId, reloadKey, token]);
+
+  return {
+    teachers,
+    loading,
+    error,
+    refetch: () => setReloadKey((currentValue) => currentValue + 1),
+  };
 }

--- a/frontend/src/modules/teachers/ui/TeachersTable.tsx
+++ b/frontend/src/modules/teachers/ui/TeachersTable.tsx
@@ -1,54 +1,79 @@
 "use client";
 
 import { EmptyState, Table, TableRowActions } from "@/src/components/ui";
-import type { TableColumn } from "@/src/components/ui";
+import type { TableColumn, SortDirection } from "@/src/components/ui";
 import { formatFullName } from "@/src/shared/utils/formatPersonName";
 import type { Teacher } from "../model/teacher";
 
 type TeachersTableProps = {
-    teachers: Teacher[];
-    onEditAction?: (teacher: Teacher) => void;
-    onDeleteAction?: (teacher: Teacher) => void;
+  teachers: Teacher[];
+  onEditAction?: (teacher: Teacher) => void;
+  onDeleteAction?: (teacher: Teacher) => void;
+  sortField?: string;
+  sortDirection?: SortDirection;
+  onSortChange?: (field: string, direction: SortDirection) => void;
 };
 
-export default function TeachersTable({ teachers, onEditAction, onDeleteAction }: TeachersTableProps) {
-    if (teachers.length === 0) {
-        return (
-            <EmptyState
-                title="No teachers found"
-                description="Teacher user accounts will appear here once they have been created."
-            />
-        );
-    }
+export default function TeachersTable({
+  teachers,
+  onEditAction,
+  onDeleteAction,
+  sortField,
+  sortDirection,
+  onSortChange,
+}: TeachersTableProps) {
+  if (teachers.length === 0) {
+    return (
+      <EmptyState
+        title="No teachers found"
+        description="Teacher user accounts will appear here once they have been created."
+      />
+    );
+  }
 
-    const columns: TableColumn<Teacher>[] = [
-        {
-            key: "fullName",
-            label: "Name",
-            render: (teacher) => formatFullName(teacher.fullName),
-        },
-        {
-            key: "email",
-            label: "Email",
-        },
-        {
-            key: "actions",
-            label: "Actions",
-            align: "right",
-            render: (teacher) => (
-                <TableRowActions
-                    onEditAction={onEditAction ? () => onEditAction(teacher) : undefined}
-                    onDeleteAction={onDeleteAction ? () => onDeleteAction(teacher) : undefined}
-                    deleteDisabled={!!teacher.assignedGroupName}
-                    deleteLabel={
-                        teacher.assignedGroupName
-                            ? `Cannot delete: assigned to group ${teacher.assignedGroupName}`
-                            : "Delete"
-                    }
-                />
-            ),
-        },
-    ];
+  const columns: TableColumn<Teacher>[] = [
+    {
+      key: "fullName",
+      label: "Name",
+      sortable: true,
+      sortKey: "fullName",
+      render: (teacher) => formatFullName(teacher.fullName),
+    },
+    {
+      key: "email",
+      label: "Email",
+      sortable: true,
+      sortKey: "email",
+    },
+    {
+      key: "actions",
+      label: "Actions",
+      align: "right",
+      render: (teacher) => (
+        <TableRowActions
+          onEditAction={onEditAction ? () => onEditAction(teacher) : undefined}
+          onDeleteAction={
+            onDeleteAction ? () => onDeleteAction(teacher) : undefined
+          }
+          deleteDisabled={!!teacher.assignedGroupName}
+          deleteLabel={
+            teacher.assignedGroupName
+              ? `Cannot delete: assigned to group ${teacher.assignedGroupName}`
+              : "Delete"
+          }
+        />
+      ),
+    },
+  ];
 
-    return <Table columns={columns} rows={teachers} rowKey={(teacher) => String(teacher.id)} />;
+  return (
+    <Table
+      columns={columns}
+      rows={teachers}
+      rowKey={(teacher) => String(teacher.id)}
+      sortField={sortField}
+      sortDirection={sortDirection}
+      onSortChange={onSortChange}
+    />
+  );
 }

--- a/frontend/src/modules/users/api/getUsers.ts
+++ b/frontend/src/modules/users/api/getUsers.ts
@@ -8,11 +8,14 @@ export async function getUsersByRole(
   page: number,
   size = 10,
   search?: string,
+  sortField = "fullName",
+  sortDirection = "asc",
 ): Promise<PageResponse<User>> {
   const params = new URLSearchParams({
     role,
     page: String(page),
     size: String(size),
+    sort: `${sortField},${sortDirection}`,
   });
   if (search && search.trim()) {
     params.set("search", search.trim());

--- a/frontend/src/modules/users/api/getUsers.ts
+++ b/frontend/src/modules/users/api/getUsers.ts
@@ -3,36 +3,49 @@ import type { PageResponse } from "@/src/shared/model/page";
 import type { User } from "../model/user";
 
 export async function getUsersByRole(
-    token: string,
-    role: string,
-    page: number,
-    size = 10,
+  token: string,
+  role: string,
+  page: number,
+  size = 10,
+  search?: string,
 ): Promise<PageResponse<User>> {
-    const response = await fetch(`${API_URL}/api/v1/users?role=${role}&page=${page}&size=${size}`, {
-        headers: {
-            Authorization: `Bearer ${token}`,
-        },
-        cache: "no-store",
-    });
+  const params = new URLSearchParams({
+    role,
+    page: String(page),
+    size: String(size),
+  });
+  if (search && search.trim()) {
+    params.set("search", search.trim());
+  }
 
-    if (!response.ok) {
-        throw new Error("Failed to fetch users");
-    }
+  const response = await fetch(`${API_URL}/api/v1/users?${params.toString()}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+    cache: "no-store",
+  });
 
-    return response.json();
+  if (!response.ok) {
+    throw new Error("Failed to fetch users");
+  }
+
+  return response.json();
 }
 
-export async function getUserOptionsByRole(token: string, role: string): Promise<User[]> {
-    const response = await fetch(`${API_URL}/api/v1/users/options?role=${role}`, {
-        headers: {
-            Authorization: `Bearer ${token}`,
-        },
-        cache: "no-store",
-    });
+export async function getUserOptionsByRole(
+  token: string,
+  role: string,
+): Promise<User[]> {
+  const response = await fetch(`${API_URL}/api/v1/users/options?role=${role}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+    cache: "no-store",
+  });
 
-    if (!response.ok) {
-        throw new Error("Failed to fetch users");
-    }
+  if (!response.ok) {
+    throw new Error("Failed to fetch users");
+  }
 
-    return response.json();
+  return response.json();
 }

--- a/frontend/src/modules/users/hooks/useUsers.ts
+++ b/frontend/src/modules/users/hooks/useUsers.ts
@@ -6,108 +6,119 @@ import { getUserOptionsByRole, getUsersByRole } from "../api/getUsers";
 import type { User } from "../model/user";
 
 export function useUsersByRole(
-    token: string | null,
-    role: string,
-    page: number,
-    size = 10,
-    enabled = true,
+  token: string | null,
+  role: string,
+  page: number,
+  size = 10,
+  enabled = true,
+  search = "",
 ) {
-    const [userPage, setUserPage] = useState<PageResponse<User> | null>(null);
-    const [users, setUsers] = useState<User[]>([]);
-    const [loading, setLoading] = useState(false);
-    const [error, setError] = useState<string | null>(null);
-    const [reloadKey, setReloadKey] = useState(0);
+  const [userPage, setUserPage] = useState<PageResponse<User> | null>(null);
+  const [users, setUsers] = useState<User[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
 
-    useEffect(() => {
-        if (!enabled || !token) {
-            return;
+  useEffect(() => {
+    if (!enabled || !token) {
+      return;
+    }
+
+    const resolvedToken = token;
+    let cancelled = false;
+
+    async function loadUsers() {
+      try {
+        setLoading(true);
+        setError(null);
+        const data = await getUsersByRole(
+          resolvedToken,
+          role,
+          page,
+          size,
+          search,
+        );
+
+        if (!cancelled) {
+          setUserPage(data);
+          setUsers(data.content);
         }
-
-        const resolvedToken = token;
-        let cancelled = false;
-
-        async function loadUsers() {
-            try {
-                setLoading(true);
-                setError(null);
-                const data = await getUsersByRole(resolvedToken, role, page, size);
-
-                if (!cancelled) {
-                    setUserPage(data);
-                    setUsers(data.content);
-                }
-            } catch (err) {
-                if (!cancelled) {
-                    setError(err instanceof Error ? err.message : "Failed to load users");
-                }
-            } finally {
-                if (!cancelled) {
-                    setLoading(false);
-                }
-            }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to load users");
         }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
 
-        void loadUsers();
+    void loadUsers();
 
-        return () => {
-            cancelled = true;
-        };
-    }, [enabled, page, reloadKey, role, size, token]);
-
-    return {
-        users,
-        userPage,
-        loading,
-        error,
-        refetch: () => setReloadKey((currentValue) => currentValue + 1),
+    return () => {
+      cancelled = true;
     };
+  }, [enabled, page, reloadKey, role, search, size, token]);
+
+  return {
+    users,
+    userPage,
+    loading,
+    error,
+    refetch: () => setReloadKey((currentValue) => currentValue + 1),
+  };
 }
 
-export function useUserOptionsByRole(token: string | null, role: string, enabled = true) {
-    const [users, setUsers] = useState<User[]>([]);
-    const [loading, setLoading] = useState(false);
-    const [error, setError] = useState<string | null>(null);
-    const [reloadKey, setReloadKey] = useState(0);
+export function useUserOptionsByRole(
+  token: string | null,
+  role: string,
+  enabled = true,
+) {
+  const [users, setUsers] = useState<User[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
 
-    useEffect(() => {
-        if (!enabled || !token) {
-            return;
+  useEffect(() => {
+    if (!enabled || !token) {
+      return;
+    }
+
+    const resolvedToken = token;
+    let cancelled = false;
+
+    async function loadUserOptions() {
+      try {
+        setLoading(true);
+        setError(null);
+        const data = await getUserOptionsByRole(resolvedToken, role);
+
+        if (!cancelled) {
+          setUsers(data);
         }
-
-        const resolvedToken = token;
-        let cancelled = false;
-
-        async function loadUserOptions() {
-            try {
-                setLoading(true);
-                setError(null);
-                const data = await getUserOptionsByRole(resolvedToken, role);
-
-                if (!cancelled) {
-                    setUsers(data);
-                }
-            } catch (err) {
-                if (!cancelled) {
-                    setError(err instanceof Error ? err.message : "Failed to load users");
-                }
-            } finally {
-                if (!cancelled) {
-                    setLoading(false);
-                }
-            }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to load users");
         }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
 
-        void loadUserOptions();
+    void loadUserOptions();
 
-        return () => {
-            cancelled = true;
-        };
-    }, [enabled, reloadKey, role, token]);
-
-    return {
-        users,
-        loading,
-        error,
-        refetch: () => setReloadKey((currentValue) => currentValue + 1),
+    return () => {
+      cancelled = true;
     };
+  }, [enabled, reloadKey, role, token]);
+
+  return {
+    users,
+    loading,
+    error,
+    refetch: () => setReloadKey((currentValue) => currentValue + 1),
+  };
 }

--- a/frontend/src/modules/users/hooks/useUsers.ts
+++ b/frontend/src/modules/users/hooks/useUsers.ts
@@ -12,6 +12,8 @@ export function useUsersByRole(
   size = 10,
   enabled = true,
   search = "",
+  sortField = "fullName",
+  sortDirection: "asc" | "desc" = "asc",
 ) {
   const [userPage, setUserPage] = useState<PageResponse<User> | null>(null);
   const [users, setUsers] = useState<User[]>([]);
@@ -37,6 +39,8 @@ export function useUsersByRole(
           page,
           size,
           search,
+          sortField,
+          sortDirection,
         );
 
         if (!cancelled) {
@@ -59,7 +63,17 @@ export function useUsersByRole(
     return () => {
       cancelled = true;
     };
-  }, [enabled, page, reloadKey, role, search, size, token]);
+  }, [
+    enabled,
+    page,
+    reloadKey,
+    role,
+    search,
+    size,
+    sortDirection,
+    sortField,
+    token,
+  ]);
 
   return {
     users,


### PR DESCRIPTION
Closes #59

## What was done

### Backend
- Added `?search=` query parameter to `GET /api/v1/groups` — filters by group name (case-insensitive)
- Added `?search=` query parameter to `GET /api/v1/users?role=TEACHER` — filters by full name (case-insensitive)
- Pagination and sorting continue to work alongside search

### Frontend
- Added search input to the Groups table page
- Added search input to the Teachers table page
- Resetting to page 1 when a new search term is entered

## Testing
- Tested locally as KINDERGARTEN_ADMIN
- Search filters results correctly on both tables
- Clearing the search input restores the full list