### PR TITLE
refactor: reorganise SecurityConfig requestMatchers by role (#68)

### DIFF
--- a/backend/src/main/java/com/team29/kindergarten/security/SecurityConfig.java
+++ b/backend/src/main/java/com/team29/kindergarten/security/SecurityConfig.java
@@ -5,7 +5,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.web.SecurityFilterChain;
@@ -35,24 +34,42 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
+
+                        // Public endpoints
                         .requestMatchers(
                                 "/auth/login",
                                 "/auth/register",
                                 "/v3/api-docs/**",
                                 "/swagger-ui/**",
-                                "/swagger-ui.html"
+                                "/swagger-ui.html",
+                                "/uploads/**"
                         ).permitAll()
-                        // Allow to get uploaded photos
-                        .requestMatchers("/uploads/**").permitAll()
 
-                        // Teacher API
+                        // Authenticated user info
+                        .requestMatchers("/auth/me").authenticated()
+
+                        // KINDERGARTEN_ADMIN endpoints
+                        .requestMatchers("/api/v1/tenants/**").hasRole("KINDERGARTEN_ADMIN")
+                        .requestMatchers("/api/v1/users/**").hasRole("KINDERGARTEN_ADMIN")
+                        .requestMatchers("/api/v1/groups/**").hasRole("KINDERGARTEN_ADMIN")
+
+                        // TEACHER-only child endpoint
+                        .requestMatchers(HttpMethod.GET, "/api/v1/children/class-records").hasRole("TEACHER")
+
+                        // Children endpoints — KINDERGARTEN_ADMIN and PARENT
+                        .requestMatchers("/api/v1/children/**").hasAnyRole("KINDERGARTEN_ADMIN", "PARENT")
+
+                        // Attendance endpoints — all authenticated roles
+                        .requestMatchers("/api/v1/attendances/**").hasAnyRole("KINDERGARTEN_ADMIN", "TEACHER", "PARENT")
+
+                        // TEACHER endpoints
                         .requestMatchers("/api/teacher/**").hasRole("TEACHER")
                         .requestMatchers("/api/upload/**").hasRole("TEACHER")
 
-                        // Admin API
-                        .requestMatchers(HttpMethod.POST, "/api/v1/users/teachers").hasRole("KINDERGARTEN_ADMIN")
-                        .requestMatchers(HttpMethod.PUT, "/api/v1/users/teachers/*").hasRole("KINDERGARTEN_ADMIN")
-                        .requestMatchers(HttpMethod.DELETE, "/api/v1/users/teachers/*").hasRole("KINDERGARTEN_ADMIN")
+                        // PARENT endpoints
+                        .requestMatchers("/api/parent/**").hasRole("PARENT")
+
+                        // Everything else requires authentication
                         .anyRequest().authenticated()
                 )
                 .sessionManagement(session ->


### PR DESCRIPTION
Closes #68

## What was done

Refactored `SecurityConfig.java` to replace repetitive per-endpoint 
`requestMatchers()` rules with grouped, role-based path rules.

### Before
Individual rules per endpoint e.g.:
- `.requestMatchers(HttpMethod.POST, "/api/v1/users/teachers").hasRole("KINDERGARTEN_ADMIN")`
- `.requestMatchers(HttpMethod.PUT, "/api/v1/users/teachers/*").hasRole("KINDERGARTEN_ADMIN")`
- `.requestMatchers(HttpMethod.DELETE, "/api/v1/users/teachers/*").hasRole("KINDERGARTEN_ADMIN")`

### After
Grouped rules by role and path prefix:
- Public: `/auth/login`, `/auth/register`, `/uploads/**`, Swagger
- KINDERGARTEN_ADMIN: `/api/v1/tenants/**`, `/api/v1/users/**`, `/api/v1/groups/**`
- TEACHER: `/api/teacher/**`, `/api/upload/**`, `/api/v1/children/class-records`
- PARENT: `/api/parent/**`
- Shared: `/api/v1/attendances/**`, `/api/v1/children/**`

## Testing
- Tested locally with KINDERGARTEN_ADMIN, TEACHER, and PARENT roles
- All portals load and function correctly
- No regressions observed